### PR TITLE
Remove chmod of script in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
-RUN chmod +x ./whoogle-search
 
 EXPOSE 5000
 


### PR DESCRIPTION
No need to chmod `whoogle-search` script inside container, It's already executable.

Tiny nitpick cleanup I noticed.