### PR TITLE
Use slim version of docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8
+FROM python:3.8-slim
 
 WORKDIR /usr/src/app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.8-slim
 
 WORKDIR /usr/src/app
-
+RUN apt-get update && apt-get install -y build-essential libcurl4-openssl-dev libssl-dev
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 


### PR DESCRIPTION
This massively reduces the size of the final container (330mb -> 60mb).

They're both still Linux based, and I believe both still based on Debian, but 1 is significantly smaller. Alpine-based was also an option, but isn't ideal for native modules.