### PR TITLE
Added option to search only via GET request

### DIFF
--- a/app/models/config.py
+++ b/app/models/config.py
@@ -57,6 +57,7 @@ class Config:
         self.dark = False
         self.nojs = False
         self.near = ''
+        self.get_only = False
 
         for key, value in kwargs.items():
             setattr(self, key, value)

--- a/app/routes.py
+++ b/app/routes.py
@@ -42,7 +42,8 @@ def index():
                            bg=bg,
                            ua=g.user_request.modified_user_agent,
                            languages=Config.LANGUAGES,
-                           current_lang=g.user_config.lang)
+                           current_lang=g.user_config.lang,
+                           request_type='get' if g.user_config.get_only else 'post')
 
 
 @app.route('/opensearch.xml', methods=['GET'])
@@ -51,7 +52,9 @@ def opensearch():
     if opensearch_url.endswith('/'):
         opensearch_url = opensearch_url[:-1]
 
-    template = render_template('opensearch.xml', main_url=opensearch_url)
+    template = render_template('opensearch.xml',
+                               main_url=opensearch_url,
+                               request_type='get' if g.user_config.get_only else 'post')
     response = make_response(template)
     response.headers['Content-Type'] = 'application/xml'
     return response

--- a/app/static/js/controller.js
+++ b/app/static/js/controller.js
@@ -13,9 +13,16 @@ const setupSearchLayout = () => {
             searchBtn.click();
         }
     });
-}
+};
 
-const fillConfigValues = (near, nojs, dark, url) => {
+const fillConfigValues = () => {
+    // Establish all config value elements
+    const near = document.getElementById("config-near");
+    const noJS = document.getElementById("config-nojs");
+    const dark = document.getElementById("config-dark");
+    const url  = document.getElementById("config-url");
+    const getOnly = document.getElementById("config-get-only");
+
     // Request existing config info
     let xhrGET = new XMLHttpRequest();
     xhrGET.open("GET", "/config");
@@ -29,15 +36,16 @@ const fillConfigValues = (near, nojs, dark, url) => {
         let configSettings = JSON.parse(xhrGET.responseText);
 
         near.value = configSettings["near"] ? configSettings["near"] : "";
-        nojs.checked = !!configSettings["nojs"];
+        noJS.checked = !!configSettings["nojs"];
         dark.checked = !!configSettings["dark"];
+        getOnly.checked = !!configSettings["get_only"];
 
         // Addresses the issue of incorrect URL being used behind reverse proxy
         url.value = configSettings["url"] ? configSettings["url"] : "";
     };
 
     xhrGET.send();
-}
+};
 
 const setupConfigLayout = () => {
     // Setup whoogle config
@@ -54,13 +62,8 @@ const setupConfigLayout = () => {
         content.classList.toggle("open");
     });
 
-    const near = document.getElementById("config-near");
-    const noJS = document.getElementById("config-nojs");
-    const dark = document.getElementById("config-dark");
-    const url  = document.getElementById("config-url");
-
-    fillConfigValues(near, noJS, dark, url);
-}
+    fillConfigValues();
+};
 
 document.addEventListener("DOMContentLoaded", function() {
     setTimeout(function() {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -26,7 +26,7 @@
     <body id="main" style="display: none; background-color: {{ bg }}">
         <div class="search-container">
             <img class="logo" src="/static/img/logo.png">
-            <form action="/search" method="post">
+            <form action="/search" method="{{ request_type }}">
                 <div class="search-fields">
                     <input type="text" name="q" id="search-bar" autofocus="autofocus">
                     <input type="submit" id="search-submit" value="Search">
@@ -65,6 +65,10 @@
                         <div class="config-div">
                             <label for="config-dark">Dark Mode: </label>
                             <input type="checkbox" name="dark" id="config-dark">
+                        </div>
+                        <div class="config-div">
+                            <label for="config-get-only">GET Requests Only: </label>
+                            <input type="checkbox" name="get_only" id="config-get-only">
                         </div>
                         <div class="config-div">
                             <label for="config-url">Root URL: </label>

--- a/app/templates/opensearch.xml
+++ b/app/templates/opensearch.xml
@@ -4,7 +4,7 @@
   <Description>Whoogle: A lightweight, deployable Google search proxy for desktop/mobile that removes Javascript, AMP links, and ads</Description>
   <InputEncoding>UTF-8</InputEncoding>
   <Image width="32" height="32" type="image/x-icon">/static/img/favicon/favicon-32x32.png</Image>
-  <Url type="text/html" method="post" template="{{ main_url }}/search">
+  <Url type="text/html" method="{{ request_type }}" template="{{ main_url }}/search">
     <Param name="q" value="{searchTerms}"/>
   </Url>
   <Url type="application/x-suggestions+json" template="{{ main_url }}/search"/>


### PR DESCRIPTION
This addresses #18, which brought up the issue of searching with Whoogle
with the search instance set to always use a specific container in
Firefox Container Tabs.

POST requests are dropped when switching container tabs, so the user is redirected to the home page. With GET requests enforced, the search query is successfully completed across container tabs. 