### PR TITLE
Fixed missing host parameter bug.

### DIFF
--- a/whoogle-search
+++ b/whoogle-search
@@ -21,5 +21,5 @@ mkdir -p $STATIC_FOLDER
 if [[ $SUBDIR == "test" ]]; then
     pytest -sv
 else
-    python3 -m app --port $PORT
+    python3 -um app --host 0.0.0.0 --port $PORT
 fi


### PR DESCRIPTION
Fixes issue #37. Copied from comment there:

> We don't see logs because python buffers its output. If we add a -u to line 24 of `whoogle-search` we can see the problem in the logs:
> 
> ```
> whoogle-search    | Serving on http://localhost:5000
> ```
> 
> During #32 the `--host 0.0.0.0` argument was left out, so the webserver only listens on localhost (despite docker exposing and publishing the port). The fix is to change line 24 in `whoogle-search` to:
> 
> ```
> python3 -um app --host "0.0.0.0" --port $PORT
> ```
> 
> Happy to send a PR if you'd like.