### PR TITLE
Feature: https only -- adds option to enforce https on running instances

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,14 @@ RUN mkdir $config_dir
 VOLUME $config_dir
 ENV CONFIG_VOLUME=$config_dir
 
-ARG use_https=1
+ARG use_https=''
 ENV HTTPS_ONLY=$use_https
+
+ARG whoogle_port=5000
+ENV EXPOSE_PORT=${EXPOSE_PORT:-$whoogle_port}
 
 COPY . .
 
-EXPOSE 5000
+EXPOSE $EXPOSE_PORT
 
 CMD ["./whoogle-search"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ARG use_https=''
 ENV HTTPS_ONLY=$use_https
 
 ARG whoogle_port=5000
-ENV EXPOSE_PORT=${EXPOSE_PORT:-$whoogle_port}
+ENV EXPOSE_PORT=$whoogle_port
 
 COPY . .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,9 @@ RUN mkdir $config_dir
 VOLUME $config_dir
 ENV CONFIG_VOLUME=$config_dir
 
+ARG use_https=1
+ENV HTTPS_ONLY=$use_https
+
 COPY . .
 
 EXPOSE 5000

--- a/README.md
+++ b/README.md
@@ -124,7 +124,9 @@ docker build --tag whoogle-search:1.0 .
 docker run --publish 5000:5000 --detach --name whoogle-search whoogle-search:1.0
 ```
 
-And kill with: `docker rm --force whooglesearch`
+And kill with: `docker rm --force whoogle-search`
+
+*NOTE: Docker containers run by default with https enforcement. If your instance will be run over http, you'll need to add `--build-arg use_https=0` to your run command.*
 
 #### Using [Heroku CLI](https://devcenter.heroku.com/articles/heroku-cli)
 ```bash

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Sandboxed temporary instance:
 ```bash
 $ whoogle-search --help
 usage: whoogle-search [-h] [--port <port number>] [--host <ip address>] [--debug]
+                      [--https-only]
 
 Whoogle Search console runner
 
@@ -79,7 +80,8 @@ optional arguments:
   -h, --help            show this help message and exit
   --port <port number>  Specifies a port to run on (default 5000)
   --host <ip address>   Specifies the host address to use (default 127.0.0.1)
-  --debug               Activates debug mode for the Flask server (default False)
+  --debug               Activates debug mode for the server (default False)
+  --https-only          Enforces HTTPS redirects for all requests (default False)
 ```
 
 ### D) Manual
@@ -95,6 +97,10 @@ pip install -r requirements.txt
 ```
 
 ### E) Manual (Docker)
+___
+*Note: Docker containers run by default with https enforcement. If your instance will be run over http, you'll need to add `--build-arg use_https=0` to your run command.*
+___
+
 1. Ensure the Docker daemon is running, and is accessible by your user account
   - To add user permissions, you can execute `sudo usermod -aG docker yourusername`
   - Running `docker ps` should return something besides an error. If you encounter an error saying the daemon isn't running, try `sudo systemctl start docker` (Linux) or ensure the docker tool is running (Windows/macOS).
@@ -125,8 +131,6 @@ docker run --publish 5000:5000 --detach --name whoogle-search whoogle-search:1.0
 ```
 
 And kill with: `docker rm --force whoogle-search`
-
-*NOTE: Docker containers run by default with https enforcement. If your instance will be run over http, you'll need to add `--build-arg use_https=0` to your run command.*
 
 #### Using [Heroku CLI](https://devcenter.heroku.com/articles/heroku-cli)
 ```bash

--- a/README.md
+++ b/README.md
@@ -97,10 +97,6 @@ pip install -r requirements.txt
 ```
 
 ### E) Manual (Docker)
-___
-*Note: Docker containers run by default with https enforcement. If your instance will be run over http, you'll need to add `--build-arg use_https=0` to your run command.*
-___
-
 1. Ensure the Docker daemon is running, and is accessible by your user account
   - To add user permissions, you can execute `sudo usermod -aG docker yourusername`
   - Running `docker ps` should return something besides an error. If you encounter an error saying the daemon isn't running, try `sudo systemctl start docker` (Linux) or ensure the docker tool is running (Windows/macOS).

--- a/app/routes.py
+++ b/app/routes.py
@@ -20,6 +20,12 @@ CONFIG_PATH = os.getenv('CONFIG_VOLUME', app.config['STATIC_FOLDER']) + '/config
 
 @app.before_request
 def before_request_func():
+    # Always redirect to https if HTTPS_ONLY is set
+    if os.getenv('HTTPS_ONLY', False) and request.url.startswith('http://'):
+        url = request.url.replace('http://', 'https://', 1)
+        code = 301
+        return redirect(url, code=code)
+
     json_config = json.load(open(CONFIG_PATH)) if os.path.exists(CONFIG_PATH) else {'url': request.url_root}
     g.user_config = Config(**json_config)
 
@@ -162,7 +168,11 @@ def run_app():
                         help='Specifies the host address to use (default 127.0.0.1)')
     parser.add_argument('--debug', default=False, action='store_true',
                         help='Activates debug mode for the server (default False)')
+    parser.add_argument('--https-only', default=False, action='store_true',
+                        help='Enforces HTTPS redirects for all requests')
     args = parser.parse_args()
+    os.environ['HTTPS_ONLY'] = '1' if args.https_only else ''
+
     if args.debug:
         app.run(host=args.host, port=args.port, debug=args.debug)
     else:

--- a/whoogle-search
+++ b/whoogle-search
@@ -21,5 +21,5 @@ mkdir -p $STATIC_FOLDER
 if [[ $SUBDIR == "test" ]]; then
     pytest -sv
 else
-    python3 -um app --host 0.0.0.0 --port $PORT
+    python3 -um app --host 0.0.0.0 --port $PORT --debug
 fi

--- a/whoogle-search
+++ b/whoogle-search
@@ -7,7 +7,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P)"
 
 # Set default port if unavailable
 if [[ -z "${PORT}" ]]; then
-    PORT=5000
+    PORT="${EXPOSE_PORT:-5000}"
 fi
 
 # Set directory to serve static content from
@@ -21,5 +21,5 @@ mkdir -p $STATIC_FOLDER
 if [[ $SUBDIR == "test" ]]; then
     pytest -sv
 else
-    python3 -um app --host 0.0.0.0 --port $PORT --debug
+    python3 -um app --host 0.0.0.0 --port $PORT
 fi


### PR DESCRIPTION
Enforces https by default on Docker instances, adds an option to enforce https if running through pip/pipx.