### PR TITLE
Feature: Allow bind address override

### DIFF
--- a/whoogle-search
+++ b/whoogle-search
@@ -3,23 +3,22 @@
 # ./whoogle-search # Runs the full web app
 # ./whoogle-search test # Runs the testing suite
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P)"
+set -euo pipefail
 
-# Set default port if unavailable
-if [[ -z "${PORT}" ]]; then
-    PORT="${EXPOSE_PORT:-5000}"
-fi
+SCRIPT_DIR="$(builtin cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 
 # Set directory to serve static content from
-[[ ! -z $1 ]] && SUBDIR="$1" || SUBDIR="app"
-export APP_ROOT=$SCRIPT_DIR/$SUBDIR
-export STATIC_FOLDER=$APP_ROOT/static
+SUBDIR="${1:-app}"
+export APP_ROOT="$SCRIPT_DIR/$SUBDIR"
+export STATIC_FOLDER="$APP_ROOT/static"
 
-mkdir -p $STATIC_FOLDER
+mkdir -p "$STATIC_FOLDER"
 
 # Check for regular vs test run
-if [[ $SUBDIR == "test" ]]; then
+if [[ "$SUBDIR" == "test" ]]; then
     pytest -sv
 else
-    python3 -um app --host 0.0.0.0 --port $PORT
+    python3 -um app \
+      --host "${ADDRESS:-0.0.0.0}" \
+      --port "${PORT:-"${EXPOSE_PORT:-5000}"}"
 fi


### PR DESCRIPTION
Allow the bind address to be controlled with an environment variable in the same way that the bind port can be controlled. This allows users to be more specific with which interface the application will listen on, enabling restriction to a private network connection on machines with multiple interfaces.

Also, performed a quick bash style pass (which I'm happy to revert if you don't like it):
* `set -euo pipefail` to catch programming errors early
* `builtin cd` instead of `cd` to correctly invoke a commonly-aliased command
* Double quotes around all variables to prevent accidental whitespace-expansion
* Use variable-defaults instead of an "if unset" block