### PR TITLE
Adding support to choose separately the langage of search and interface.

### DIFF
--- a/app/models/config.py
+++ b/app/models/config.py
@@ -2,6 +2,7 @@ class Config:
     # Derived from here:
     # https://sites.google.com/site/tomihasa/google-language-codes#searchlanguage
     LANGUAGES = [
+        {'name': 'Default (use server location)', 'value': ''},
         {'name': 'English', 'value': 'lang_en'},
         {'name': 'Afrikaans', 'value': 'lang_af'},
         {'name': 'Arabic', 'value': 'lang_ar'},
@@ -298,7 +299,8 @@ class Config:
 
     def __init__(self, **kwargs):
         self.url = ''
-        self.lang = 'lang_en'
+        self.lang_search = ''
+        self.lang_interface = ''
         self.ctry = ''
         self.safe = False
         self.dark = False

--- a/app/request.py
+++ b/app/request.py
@@ -66,10 +66,10 @@ def gen_query(query, args, config, near_city=None):
         param_dict['source'] = '&source=' + args.get('source')
         param_dict['lr'] = ('&lr=' + ''.join([_ for _ in sub_lang if not _.isdigit()])) if sub_lang else ''
     else:
-        param_dict['lr'] = '&lr=' + config.lang
+        param_dict['lr'] = ('&lr=' + config.lang_search) if config.lang_search else ''
 
     param_dict['cr'] = ('&cr=' + config.ctry) if config.ctry else ''
-    param_dict['hl'] = '&hl=' + config.lang.replace('lang_', '')
+    param_dict['hl'] = ('&hl=' + config.lang_interface.replace('lang_', '')) if config.lang_interface else ''
     param_dict['safe'] = '&safe=' + ('active' if config.safe else 'off')
 
     for val in param_dict.values():

--- a/app/routes.py
+++ b/app/routes.py
@@ -59,13 +59,13 @@ def before_request_func():
 
     if https_only and request.url.startswith('http://'):
         return redirect(request.url.replace('http://', 'https://', 1), code=308)
-
+    
     g.user_config = Config(**session['config'])
 
     if not g.user_config.url:
         g.user_config.url = request.url_root.replace('http://', 'https://') if https_only else request.url_root
 
-    g.user_request = Request(request.headers.get('User-Agent'), language=g.user_config.lang)
+    g.user_request = Request(request.headers.get('User-Agent'), language=g.user_config.lang_search)
     g.app_location = g.user_config.url
 
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -55,11 +55,24 @@
                             </select>
                         </div>
                         <div class="config-div">
-                            <label for="config-lang">Language: </label>
-                            <select name="lang" id="config-lang">
+                            <label for="config-lang-interface">Interface Language: </label>
+                            <select name="lang_interface" id="config-lang-interface">
                                 {% for lang in languages %}
                                 <option value="{{ lang.value }}"
-                                    {% if lang.value in config.lang %}
+                                    {% if lang.value in config.lang_interface %}
+                                        selected
+                                    {% endif %}>
+                                    {{ lang.name }}
+                                </option>
+                                {% endfor %}
+                            </select>
+                        </div>
+                        <div class="config-div">
+                            <label for="config-lang-search">Search Language: </label>
+                            <select name="lang_search" id="config-lang-search">
+                                {% for lang in languages %}
+                                <option value="{{ lang.value }}"
+                                    {% if lang.value in config.lang_search %}
                                         selected
                                     {% endif %}>
                                     {{ lang.name }}

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -6,7 +6,8 @@ demo_config = {
     'near': random.choice(['Seattle', 'New York', 'San Francisco']),
     'dark_mode': str(random.getrandbits(1)),
     'nojs': str(random.getrandbits(1)),
-    'lang': random.choice(Config.LANGUAGES)['value'],
+    'lang_interface': random.choice(Config.LANGUAGES)['value'],
+    'lang_search': random.choice(Config.LANGUAGES)['value'],
     'ctry': random.choice(Config.COUNTRIES)['value']
 }
 


### PR DESCRIPTION
There are small changes to allow the user to choose separately the interface and search language.
In addition, it allows to not specify any so google choose the best. This is important for people using several languages, if you specify a specific language and make a search in another one the results are not very accurate.

Maybe a better name for the variable should be choose... I was not very inspired.