### PR TITLE
Allow for free deployment to Repl.it

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "pip install -r requirements.txt && ./run"

--- a/README.md
+++ b/README.md
@@ -56,10 +56,19 @@ There are a few different ways to begin using the app, depending on your prefere
 
 Provides:
 - Free deployment of app
-- Free https url (https://\<your app name\>.herokuapp.com)
+- Free HTTPS url (https://\<your app name\>.herokuapp.com)
 - Downtime after periods of inactivity \([solution](https://github.com/benbusby/whoogle-search#prevent-downtime-heroku-only)\)
 
-### B) [pipx](https://github.com/pipxproject/pipx#install-pipx)
+### B) [Repl.it](https://repl.it)
+[![Run on Repl.it](https://repl.it/badge/github/benbusby/whoogle-search)](https://repl.it/github/benbusby/whoogle-search)
+
+Provides:
+- Free deployment of app (can be ran without account)
+- Free HTTPS url (https://\<app name\>.\<username\>\.repl\.co)
+    - Supports custom domains
+- Downtime after periods of inactivity \([solution 1](https://repl.it/talk/ask/use-this-pingmat1replco-just-enter/28821/101298), [solution 2](https://repl.it/talk/learn/How-to-use-and-setup-UptimeRobot/9003)\)
+
+### C) [pipx](https://github.com/pipxproject/pipx#install-pipx)
 Persistent install:
 
 `pipx install git+https://github.com/benbusby/whoogle-search.git`
@@ -68,7 +77,7 @@ Sandboxed temporary instance:
 
 `pipx run git+https://github.com/benbusby/whoogle-search.git whoogle-search`
 
-### C) pip
+### D) pip
 `pip install whoogle-search`
 
 ```bash
@@ -86,7 +95,7 @@ optional arguments:
   --https-only          Enforces HTTPS redirects for all requests (default False)
 ```
 
-### D) Manual
+### E) Manual
 Clone the repo and run the following commands to start the app in a local-only environment:
 
 ```bash
@@ -125,7 +134,7 @@ sudo systemctl enable whoogle
 sudo systemctl start whoogle
 ```
 
-### E) Manual (Docker)
+### F) Manual (Docker)
 1. Ensure the Docker daemon is running, and is accessible by your user account
   - To add user permissions, you can execute `sudo usermod -aG docker yourusername`
   - Running `docker ps` should return something besides an error. If you encounter an error saying the daemon isn't running, try `sudo systemctl start docker` (Linux) or ensure the docker tool is running (Windows/macOS).


### PR DESCRIPTION
Hi!

I've added the config `.replit` file and have listed Repl.it as one of the deployment options in the README.

This might suit some people better than Heroku as you can deploy without an account and are not limited by Heroku's Dyno hours.