### PR TITLE
Fixed annoying browser autocomplete

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -34,7 +34,7 @@
             <form id="search-form" action="/search" method="{{ 'get' if config.get_only else 'post' }}">
                 <div class="search-fields">
                     <div class="autocomplete">
-                        <input type="text" name="q" id="search-bar" autofocus="autofocus">
+                        <input type="text" name="q" id="search-bar" autofocus="autofocus" autocomplete="off">
                     </div>
                     <input type="submit" id="search-submit" value="Search">
                 </div>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/11898833/94837449-ca471080-0403-11eb-8a6f-48d388be7833.png)

Hello! Big fan of Whoogle but when I used it, I noticed that Firefox decided it would be a great idea to display it's own auto complete right over the top of Whoogle's. So I made a little change to ensure that this doesn't happen :smile: Hopefully this is all OK. Be sure to let me know if there is anything troubling you about this.

 \- Curlpipe