### PR TITLE
Correct Repl.it account requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Provides:
 [![Run on Repl.it](https://repl.it/badge/github/benbusby/whoogle-search)](https://repl.it/github/benbusby/whoogle-search)
 
 Provides:
-- Free deployment of app (can be ran without account)
+- Free deployment of app
 - Free HTTPS url (https://\<app name\>.\<username\>\.repl\.co)
     - Supports custom domains
 - Downtime after periods of inactivity \([solution 1](https://repl.it/talk/ask/use-this-pingmat1replco-just-enter/28821/101298), [solution 2](https://repl.it/talk/learn/How-to-use-and-setup-UptimeRobot/9003)\)


### PR DESCRIPTION
Repl.it has deprecated the anonymous experience so I have removed the part of the README stating that users can host on Repl.it without an account.