### PR TITLE
Add Docker Security Best Practices to docker-compose file.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,26 @@
-version: "3"
+# cant use mem_limit in a 3.x docker-compose file in non swarm mode
+# see https://github.com/docker/compose/issues/4513
+version: "2.4"
 
 services:
   whoogle-search:
     image: benbusby/whoogle-search
     container_name: whoogle-search
+    restart: on-failure:5
+    pids_limit: 50
+    mem_limit: 256mb
+    memswap_limit: 256mb
+    # user debian-tor from tor package
+    user: '102'
+    security_opt:
+      - no-new-privileges
+    cap_drop:
+      - ALL
+    read_only: true
+    tmpfs:
+      - /config/:size=10M,uid=102,gid=102,mode=1700
+      - /var/lib/tor/:size=10M,uid=102,gid=102,mode=1700
+      - /run/tor/:size=1M,uid=102,gid=102,mode=1700
     #environment: # Uncomment to configure environment variables
       # Basic auth configuration, uncomment to enable
       #- WHOOGLE_USER=<auth username>


### PR DESCRIPTION
This adds several security improvement to the docker-compose file to protect the host system.

- Don't run container as root user. Container processes shouldn't have root priviliges to the Kernel on host system.
- Run container with a read-only main volume. Container are immutable instances. Use tmpfs if the app need to write temporary files.
- Limit resources like RAM and PIDs.

From **CIS Docker Community Edition Benchmark** and **[OWASP Docker Security Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html)**.

I couldn't successfully test a search connection over tor. This didn't even work with a original `benbusby/whoogle-search` image.  
I misuse the `debian-tor` user (uid 102) to get the `tor` and the `python` process running in the image.

Additionaly i would like to discuss two things:
- It would be better to create separate user in the `Dockerfile` (and set it with `USER ...`) to run `python3 -um app ...`. This allows more specific permission grants for the python app.
- The `tor` process should be moved a seperate container and started as a second service via the docker-compose file. This could also make the tor connection more optional.