### PR TITLE
Remove public instance, Markdown edit

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,9 +339,8 @@ A lot of the app currently piggybacks on Google's existing support for fetching 
 
 *Note: Use public instances at your own discretion. Maintainers of Whoogle do not personally validate the integrity of these instances, and popular public instances are more likely to be rate-limited or blocked.*
 
-- https://whoogle.sdf.org
-- https://whoogle.tormentasolar.win/
-- https://whoogle.himiko.cloud
+- [https://whoogle.sdf.org](https://whoogle.sdf.org)
+- [https://whoogle.tormentasolar.win/](https://whoogle.tormentasolar.win/)
 
 ## Screenshots
 #### Desktop


### PR DESCRIPTION
One of the public instances listed in the README currently does not lead to a Whoogle page, this PR removes the link to it. In addition, it adds a Markdown formatted link to the links in the public instances section. This improves compatibility with regular Markdown (GFM auto-links non-formatted links, but regular Markdown does not).