### PR TITLE
Fix manifest.json not loading

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -41,6 +41,7 @@ app.config['BANG_FILE'] = os.path.join(
     app.config['BANG_PATH'],
     'bangs.json')
 app.config['CSP'] = 'default-src \'none\';' \
+                    'manifest-src \'self\';' \
                     'img-src \'self\';' \
                     'style-src \'self\' \'unsafe-inline\';' \
                     'script-src \'self\';' \


### PR DESCRIPTION
The error on the console fix
`Refused to load manifest from 'https://xxxxx.xxx/static/img/favicon/manifest.json' because it violates the following Content Security Policy directive: "default-src 'none'". Note that 'manifest-src' was not explicitly set, so 'default-src' is used as a fallback.`