### PR TITLE
Configuring PWA for Mobile Browser

### DIFF
--- a/app/static/img/favicon/manifest.json
+++ b/app/static/img/favicon/manifest.json
@@ -1,38 +1,42 @@
 {
- "name": "App",
+ "name": "Whoogle Search",
+ "short_name": "Whoogle",
+ "display": "fullscreen",
+ "scope": "/",
+ "start_url": "$APP_ROOT/templates/index.html",
  "icons": [
   {
-   "src": "\/android-icon-36x36.png",
+   "src": "android-icon-36x36.png",
    "sizes": "36x36",
    "type": "image\/png",
    "density": "0.75"
   },
   {
-   "src": "\/android-icon-48x48.png",
+   "src": "android-icon-48x48.png",
    "sizes": "48x48",
    "type": "image\/png",
    "density": "1.0"
   },
   {
-   "src": "\/android-icon-72x72.png",
+   "src": "android-icon-72x72.png",
    "sizes": "72x72",
    "type": "image\/png",
    "density": "1.5"
   },
   {
-   "src": "\/android-icon-96x96.png",
+   "src": "android-icon-96x96.png",
    "sizes": "96x96",
    "type": "image\/png",
    "density": "2.0"
   },
   {
-   "src": "\/android-icon-144x144.png",
+   "src": "android-icon-144x144.png",
    "sizes": "144x144",
    "type": "image\/png",
    "density": "3.0"
   },
   {
-   "src": "\/android-icon-192x192.png",
+   "src": "android-icon-192x192.png",
    "sizes": "192x192",
    "type": "image\/png",
    "density": "4.0"


### PR DESCRIPTION
Finxing PWA issue for Mobile Phones.
icon loading issue.

Before: 
<img width="1081" alt="Console error" src="https://user-images.githubusercontent.com/12117121/111904842-dd5fa280-8a6e-11eb-99dd-9fa8512568ff.png">

<img width="400" alt="Application error" src="https://user-images.githubusercontent.com/12117121/111904845-e05a9300-8a6e-11eb-92c1-7233d286b57e.png">
No logo

![Before](https://user-images.githubusercontent.com/12117121/111904864-f36d6300-8a6e-11eb-979b-f45d725702fb.jpg)

After this fix:

Install on firefox.
![Install    Settings menu](https://user-images.githubusercontent.com/12117121/111904908-14ce4f00-8a6f-11eb-8a05-3136bd3f2d41.jpg)

We got logo!
![Add to home screen now](https://user-images.githubusercontent.com/12117121/111904909-17c93f80-8a6f-11eb-920e-249618800f91.jpg)

I did checked on few browser and iPhone.
Looks good.



