### PR TITLE
Add wget to container build otherwise the healthcheck won't work.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ FROM python:3.8-slim
 RUN apt-get update && apt-get install -y \
     libcurl4-openssl-dev \
     tor \
+    wget \
     && rm -rf /var/lib/apt/lists/*
 
 ARG config_dir=/config


### PR DESCRIPTION
You kinda need a wget binary in the container if you are gonna use wget in the healthcheck.