### PR TITLE
always open non-result links in same window

### DIFF
--- a/app/filter.py
+++ b/app/filter.py
@@ -232,6 +232,7 @@ class Filter:
                 param_val = query_params[param][0]
                 new_search += '&' + param + '=' + param_val
             link['href'] = new_search
+            link['target'] = '_self'
         elif 'url?q=' in href:
             # Strip unneeded arguments
             link['href'] = filter_link_args(query_link)


### PR DESCRIPTION
The current behavior of turning on "Open Links in New Tab" makes all links open in new window, including "Videos", "News", "Images", and even the "Next>" button!

This PR sets target attribute to "_self" for non-result links so that they will not be opened in a new window.