### PR TITLE
Added onBoot in .replit

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,2 +1,3 @@
 language = "python3"
 run = "./run"
+onBoot = "./run"


### PR DESCRIPTION
onBoot: Command that is executed once when the repl first starts up

Example: Instance has not been visited for a longer time