### PR TITLE
Add divider to user-defined CSS + improve dark theme

### DIFF
--- a/app/static/css/dark-theme.css
+++ b/app/static/css/dark-theme.css
@@ -65,6 +65,18 @@ select {
     background-color: var(--whoogle-dark-result-bg) !important;   
 }
 
+.x54gtf {
+    background-color: var(--whoogle-dark-divider) !important;
+}
+
+.Q0HXG {
+    background-color: var(--whoogle-dark-divider) !important;
+}
+
+.LKSyXe {
+    background-color: var(--whoogle-dark-divider) !important;
+}
+
 #search-bar {
     border-color: var(--whoogle-dark-element-bg) !important;
     color: var(--whoogle-dark-text) !important;

--- a/app/static/css/light-theme.css
+++ b/app/static/css/light-theme.css
@@ -40,6 +40,19 @@ select {
     background-color: var(--whoogle-result-bg) !important;   
 }
 
+.x54gtf {
+    background-color: var(--whoogle-divider) !important;
+}
+
+.Q0HXG {
+    background-color: var(--whoogle-divider) !important;
+}
+
+.LKSyXe {
+    background-color: var(--whoogle-divider) !important;
+}
+
+
 a:visited h3 div {
     color: var(--whoogle-result-visited) !important;
 }

--- a/app/static/css/variables.css
+++ b/app/static/css/variables.css
@@ -11,6 +11,7 @@
     --whoogle-result-title: #1967d2;
     --whoogle-result-url: #0d652d;
     --whoogle-result-visited: #4b11a8;
+    --whoogle-divider: #dfe1e5;
 
     /* DARK THEME COLORS */
     --whoogle-dark-logo: #888888;
@@ -23,4 +24,5 @@
     --whoogle-dark-result-title: #dddddd;
     --whoogle-dark-result-url: #eceff4;
     --whoogle-dark-result-visited: #959595;
+    --whoogle-dark-divider: #111111;
 }


### PR DESCRIPTION
Added `--whoogle-divider` and `--whoogle-dark-divider` variables for user-defined css.

**Dark Theme**
Before:
![3](https://user-images.githubusercontent.com/37732050/117699980-fe15c000-b1b4-11eb-8c9f-a693aee0e91a.png)
![Screenshot from 2021-05-10 22-44-10](https://user-images.githubusercontent.com/37732050/117699987-ffdf8380-b1b4-11eb-9524-4e949b7313f8.png)

After:
![1](https://user-images.githubusercontent.com/37732050/117700049-0f5ecc80-b1b5-11eb-8afe-b7a5e28ff38e.png)
![2](https://user-images.githubusercontent.com/37732050/117700054-11289000-b1b5-11eb-8a1f-45d7da6f1742.png)
