### PR TITLE
Fixed German name

### DIFF
--- a/app/static/settings/languages.json
+++ b/app/static/settings/languages.json
@@ -18,7 +18,7 @@
   {"name": "Filipino (Pilipino)", "value": "lang_tl"},
   {"name": "Finnish (Suomalainen)", "value": "lang_fi"},
   {"name": "French (Français)", "value": "lang_fr"},
-  {"name": "German (Deutsche)", "value": "lang_de"},
+  {"name": "German (Deutsch)", "value": "lang_de"},
   {"name": "Greek (Ελληνικά)", "value": "lang_el"},
   {"name": "Hebrew (עִברִית)", "value": "lang_iw"},
   {"name": "Hindi (हिंदी)", "value": "lang_hi"},


### PR DESCRIPTION
Translators often translate "German" to "Deutsche", but in this context you use "Deutsch". "Deutsche" is used as an adjective.