### PR TITLE
Make replit install all requirements first

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,3 +1,3 @@
 language = "python3"
 run = "./run"
-onBoot = "./run"
+onBoot = "pip install -r requirements.txt && ./run"

--- a/.replit
+++ b/.replit
@@ -1,3 +1,3 @@
-language = "python3"
-run = "./run"
+language = "bash"
+run = "pip install -r requirements.txt && ./run"
 onBoot = "pip install -r requirements.txt && ./run"


### PR DESCRIPTION
This should install all requirements from requirements.txt. It makes this a one click experience, without the user having to run `pip install -r requirements.txt` and then tap the run button. I myself had to first run that command in my repl, so I have made this change so others don't have to do the same.

repl.it also runs on linux based systems, so `&&` is the correct bash syntax.