### PR TITLE
Fix white background on dropdown for result selectors, time etc

### DIFF
--- a/app/static/css/dark-theme.css
+++ b/app/static/css/dark-theme.css
@@ -89,6 +89,10 @@ select {
     border-color: var(--whoogle-dark-element-bg) !important;
 }
 
+.sa1toc {
+	background: var(--whoogle-dark-element-bg) !important;
+}
+
 #search-bar {
     border-color: var(--whoogle-dark-element-bg) !important;
     color: var(--whoogle-dark-text) !important;


### PR DESCRIPTION
Guess google changed something ? Dark theme dropdowns became almost unreadable.