### PR TITLE
Fix rtl lang problem in search box

### DIFF
--- a/app/templates/header.html
+++ b/app/templates/header.html
@@ -19,7 +19,8 @@
                             class="noHIxc" 
                             name="q"
                             type="text" 
-                            value="{{ clean_query(query) }}">
+                            value="{{ clean_query(query) }}"
+                            dir="auto">
                         <input id="search-reset" type="reset" value="x">
                         <input name="tbm" value="{{ search_type }}" style="display: none">
                         <input type="submit" style="display: none;">
@@ -51,7 +52,8 @@
                             name="q"
                             spellcheck="false"
                             type="text"
-                            value="{{ clean_query(query) }}">
+                            value="{{ clean_query(query) }}"
+                            dir="auto">
                         <input name="tbm" value="{{ search_type }}" style="display: none">
                         <input type="submit" style="display: none;">
                         <div class="sc"></div>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -62,7 +62,8 @@
 							autocapitalize="none"
 							spellcheck="false"
 							autocorrect="off"
-							autocomplete="off">
+							autocomplete="off"
+						        dir="auto">
 					</div>
 					<input type="submit" id="search-submit" value="{{ translation['search'] }}">
 				</div>

--- a/app/templates/search.html
+++ b/app/templates/search.html
@@ -8,6 +8,7 @@
             spellcheck="false"
             autocorrect="off"
             placeholder="Whoogle Search"
-            autocomplete="off">
+            autocomplete="off"
+            dir="auto">
     <input type="submit" style="width: 9%" id="search-submit" value="Search">
 </form>


### PR DESCRIPTION
Before
![image](https://user-images.githubusercontent.com/53198048/130852301-dcb641d9-d26e-482d-a1f0-4ba33f024371.png)

After
![image](https://user-images.githubusercontent.com/53198048/130852391-7a5f550a-c4fd-4606-bc04-f285384e0e20.png)

Computers support two kinds of text flow:

* "LTR": from left to right, like most western languages
* "RTL": from right to left, like Arabic, Persian and Hebrew
