### PR TITLE
Take the conventional name instead.

### DIFF
--- a/app/static/settings/countries.json
+++ b/app/static/settings/countries.json
@@ -213,7 +213,7 @@
   {"name": "Sweden", "value": "countrySE"},
   {"name": "Switzerland", "value": "countryCH"},
   {"name": "Syrian Arab Republic", "value": "countrySY"},
-  {"name": "Taiwan, Province of China", "value": "countryTW"},
+  {"name": "Taiwan", "value": "countryTW"},
   {"name": "Tajikistan", "value": "countryTJ"},
   {"name": "Tanzania, United Republic of", "value": "countryTZ"},
   {"name": "Thailand", "value": "countryTH"},


### PR DESCRIPTION
Not sure how the list in countries.json are generated or whether that should be manually edited -- if somewhere else needs to be edited together please let me know.
