### PR TITLE
Strip SKIP_PREFIX for SITE_ALTS only

### DIFF
--- a/app/utils/results.py
+++ b/app/utils/results.py
@@ -78,10 +78,9 @@ def get_site_alt(link: str) -> str:
             continue
 
         link = link.replace(site_key, SITE_ALTS[site_key])
+        for prefix in SKIP_PREFIX:
+            link = link.replace(prefix, '//')
         break
-
-    for prefix in SKIP_PREFIX:
-        link = link.replace(prefix, '//')
 
     return link
 


### PR DESCRIPTION
The current codes strip `www.` from all links, affecting sites where `foo.bar` does not redirect to `www.foo.bar`.
