### PR TITLE
Use DynamicUser in whoogle.service #453

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Description=Whoogle
 # Load values from dotenv only
 #Environment=WHOOGLE_DOTENV=1
 Type=simple
-User=<username>
+DynamicUser=true
 WorkingDirectory=<whoogle_directory>
 ExecStart=<whoogle_directory>/venv/bin/python3 -um app --host 0.0.0.0 --port 5000
 ExecReload=/bin/kill -HUP $MAINPID


### PR DESCRIPTION
Quote from https://www.freedesktop.org/software/systemd/man/systemd.exec.html

> DynamicUser= takes a boolean parameter. If set, a UNIX user and group
pair is allocated dynamically when the unit is started, and released as
soon as it is stopped. The user and group will not be added to
/etc/passwd or /etc/group, but are managed transiently during runtime.

`DynamicUser` creates dynamically a new user `whoogle` with limited
priviliges which are handled by systemd every time whoogle.service is
started. I think this is more secure and easier rather than letting the
admin deal with the user and its priviliges under which whoogle should
run. Its certainly a big security improvement compared to the root-user
which was used to run whoogle not that long ago.

I changed my `whoogle.service` file accordingly and running `ps u -U
whoogle` shows me that systemd automatically runs whoogle with the user
`whoogle` which systemd created automatically because I never created
the user myself.

```
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
whoogle     6299  0.0  0.7 363884 58808 ?        Ssl  20:14   0:01 /opt/whoogle-search/venv/bin/python3 -um app --host 0.0.0.0 --port 5000
```