### PR TITLE
Fix for #564 (lsof not found)

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,3 +1,3 @@
 language = "bash"
-run = "kill $(lsof -t -i:5000) > /dev/null 2>&1; pip install -r requirements.txt && ./run"
-onBoot = "kill $(lsof -t -i:5000) > /dev/null 2>&1; pip install -r requirements.txt && ./run"
+run = "install-pkg lsof && kill $(lsof -t -i:5000) > /dev/null 2>&1; pip install -r requirements.txt && ./run"
+onBoot = "install-pkg lsof && kill $(lsof -t -i:5000) > /dev/null 2>&1; pip install -r requirements.txt && ./run"

--- a/.replit
+++ b/.replit
@@ -1,3 +1,3 @@
 language = "bash"
-run = "install-pkg lsof && kill $(lsof -t -i:5000) > /dev/null 2>&1; pip install -r requirements.txt && ./run"
-onBoot = "install-pkg lsof && kill $(lsof -t -i:5000) > /dev/null 2>&1; pip install -r requirements.txt && ./run"
+run = "killall -q python3 > /dev/null 2>&1; pip install -r requirements.txt && ./run"
+onBoot = "killall -q python3 > /dev/null 2>&1; pip install -r requirements.txt && ./run"


### PR DESCRIPTION
Fixes  #564
This will increase the deployment time tho... as it updates the repo and then installs a package before running replit.. 
I see no other workaround tho,
maybe downloading lsof binary manually?