### PR TITLE
Fix malformed systemd service file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,12 +207,14 @@ Description=Whoogle
 #Environment=WHOOGLE_DOTENV=1
 Type=simple
 User=<username>
-WorkingDirectory=<whoogle_directory>
-# <whoogle_directory> is the directory from which the
-# systemd service will be launched. It doesn't really matter
+# If installed as a package, add:
 ExecStart=<python_install_dir>/python3 <whoogle_install_dir>/whoogle-search --host 127.0.0.1 --port 5000
 # For example:
-# /usr/bin/python3 /home/my_username/.local/bin/whoogle-search --host 127.0.0.1 --port 5000
+# ExecStart=/usr/bin/python3 /home/my_username/.local/bin/whoogle-search --host 127.0.0.1 --port 5000
+# Otherwise if running the app from source, add:
+ExecStart=<whoogle_repo_dir>/run
+# For example:
+# ExecStart=/var/www/whoogle-search/run
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=always
 RestartSec=3

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ pip install -r requirements.txt
 See the [available environment variables](#environment-variables) for additional configuration.
 
 #### systemd Configuration
-After building the virtual environment, you can add the following to `/lib/systemd/system/whoogle.service` to set up a Whoogle Search systemd service:
+After building the virtual environment, you can add something like the following to `/lib/systemd/system/whoogle.service` to set up a Whoogle Search systemd service:
 
 ```ini
 [Unit]
@@ -208,7 +208,11 @@ Description=Whoogle
 Type=simple
 User=<username>
 WorkingDirectory=<whoogle_directory>
-ExecStart=<whoogle_directory>/venv/bin/python3 -um app --host 0.0.0.0 --port 5000
+# <whoogle_directory> is the directory from which the
+# systemd service will be launched. It doesn't really matter
+ExecStart=<python_install_dir>/python3 <whoogle_install_dir>/whoogle-search --host 127.0.0.1 --port 5000
+# For example:
+# /usr/bin/python3 /home/my_username/.local/bin/whoogle-search --host 127.0.0.1 --port 5000
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=always
 RestartSec=3


### PR DESCRIPTION
In particular, the ExecStart instruction is just wrong at the moment.

Trying `python3 -um whoogle-search` throws an error
because `whoogle-search` is not a module.

`--host 0.0.0.0 --port 5000` is unnecessary given the defaults.
I've changed it to `--host 127.0.0.1 --port 5000` because
that seems more meaningful.