### PR TITLE
Improve formatting of collapsible infobox

### DIFF
--- a/app/filter.py
+++ b/app/filter.py
@@ -178,10 +178,17 @@ class Filter:
             # Find and decompose the first element with an inner HTML text val.
             # This typically extracts the title of the section (i.e. "Related
             # Searches", "People also ask", etc)
+            # If there are more than one child tags with text
+            # parenthesize the rest except the first
             label = 'Collapsed Results'
+            subtitle = None
             for elem in result_children:
                 if elem.text:
-                    label = elem.text
+                    content = list(elem.strings)
+                    label = content[0]
+                    if len(content) > 1:
+                        subtitle = '<span> (' + \
+                            ''.join(content[1:]) + ')</span>'
                     elem.decompose()
                     break
 
@@ -196,6 +203,11 @@ class Filter:
             details = BeautifulSoup(features='html.parser').new_tag('details')
             summary = BeautifulSoup(features='html.parser').new_tag('summary')
             summary.string = label
+
+            if subtitle:
+                soup = BeautifulSoup(subtitle, 'html.parser')
+                summary.append(soup)
+
             details.append(summary)
 
             if parent and not minimal_mode:

--- a/app/static/css/search.css
+++ b/app/static/css/search.css
@@ -26,6 +26,10 @@ details summary {
     font-weight: bold;
 }
 
+details summary span {
+    font-weight: normal;
+}
+
 #lingva-iframe {
     width: 100%;
     height: 650px;


### PR DESCRIPTION
Some long infoboxes (typically movies, artists) are treated as collapsibles due to having more than 5 child divs. This PR improves the subtitle (typically year, length, genre, profession, links etc.) display by putting it in parentheses and appending to title. Also sets its font weight to normal.

A instance is running [here](https://whoogle-test.fly.dev/) with the changes until this is merged.


![before](https://user-images.githubusercontent.com/58942389/149619837-83bb488e-747f-4629-ab70-67cfe52c3c2c.png)
**Before**
***
![after](https://user-images.githubusercontent.com/58942389/149619862-c97f2f4e-5ec4-46d2-8b72-036aeee9f112.png)
**After**