### PR TITLE
Allow Docker container to be run as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apk add --update --no-cache tor curl bash openrc
 # libcurl4-openssl-dev
 
 ARG config_dir=/config
-RUN mkdir -p $config_dir
+RUN mkdir -p -m 777 $config_dir
 VOLUME $config_dir
 
 ARG username=''


### PR DESCRIPTION
The /config directory needs to be writable by all in order to run the container as a non-root user.