### PR TITLE
Give Accept-Language div its own class

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -200,7 +200,7 @@
                             <input type="checkbox" name="get_only"
                                    id="config-get-only" {{ 'checked' if config.get_only else '' }}>
                         </div>
-                        <div class="config-div config-div-get-only">
+                        <div class="config-div config-div-accept-language">
                             <label for="config-accept-language">Set Accept-Language: </label>
                             <input type="checkbox" name="accept_language"
                                    id="config-accept-language" {{ 'checked' if config.accept_language else '' }}>


### PR DESCRIPTION
Minor change. Noticed this when I wanted to hide accept-language but not get-only for my personal instance.