### PR TITLE
Increase /var/lib/tor tmpfs size to 12MB

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       - ALL
     tmpfs:
       - /config/:size=10M,uid=927,gid=927,mode=1700
-      - /var/lib/tor/:size=10M,uid=927,gid=927,mode=1700
+      - /var/lib/tor/:size=15M,uid=927,gid=927,mode=1700
       - /run/tor/:size=1M,uid=927,gid=927,mode=1700
     #environment: # Uncomment to configure environment variables
       # Basic auth configuration, uncomment to enable


### PR DESCRIPTION
I increased the tmpfs size for /var/lib/tor to 12MB. This will fix issue #648.

After an uptime of 109 days, the usage of /var/lib/tor was still 10.9 MB. A reply in issue #648 reported a higher usage, which forced me to set the size a bit higher (12MB instead of 11MB).