### PR TITLE
Fix incorrect translation (zh-TW & zh-CN)

### DIFF
--- a/app/static/settings/translations.json
+++ b/app/static/settings/translations.json
@@ -346,8 +346,8 @@
         "continue-search": "继续搜索 Farside",
         "all": "全部",
         "images": "圖片",
-        "maps": "影片",
-        "videos": "地圖",
+        "maps": "地圖",
+        "videos": "影片",
         "news": "新聞",
         "books": "書籍"
     },
@@ -566,8 +566,8 @@
         "continue-search": "繼續搜索 Farside",
         "all": "全部",
         "images": "圖片",
-        "maps": "影片",
-        "videos": "地圖",
+        "maps": "地圖",
+        "videos": "影片",
         "news": "新聞",
         "books": "書籍"
     },


### PR DESCRIPTION
Translation for `maps` and `videos` were swapped in this commit.

https://github.com/benbusby/whoogle-search/commit/11099f7b1dc2bc497555ccf13521b02e3f1c35d7#diff-fcd1e088df6519cbd45d012f89a0d2722b7414c94189ee41595a3a101b4c11ad