### PR TITLE
Do not offer opensearch.xml as attachment

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -251,7 +251,7 @@ def opensearch():
         'opensearch.xml',
         main_url=opensearch_url,
         request_type='' if get_only else 'method="post"'
-    ), 200, {'Content-Disposition': 'attachment; filename="opensearch.xml"'}
+    ), 200, {'Content-Type': 'application/xml'}
 
 
 @app.route(f'/{Endpoint.search_html}', methods=['GET'])


### PR DESCRIPTION
Do not offer opensearch.xml as an attachment; I have not seen it done anywhere else and concluded that it is unnecessary.

It will also allow inspecting the XML file via browser without downloading it.