### PR TITLE
Add support for relative search results

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN mkdir -p $config_dir
 RUN chmod a+w $config_dir
 VOLUME $config_dir
 
+ARG url_prefix=''
 ARG username=''
 ARG password=''
 ARG proxyuser=''
@@ -45,6 +46,7 @@ ARG imgur_alt='farside.link/rimgo'
 ARG wikipedia_alt='farside.link/wikiless'
 
 ENV CONFIG_VOLUME=$config_dir \
+    WHOOGLE_URL_PREFIX=$url_prefix \
     WHOOGLE_USER=$username \
     WHOOGLE_PASS=$password \
     WHOOGLE_PROXY_USER=$proxyuser \

--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@ There are a few optional environment variables available for customizing a Whoog
 
 | Variable             | Description                                                                               |
 | -------------------- | ----------------------------------------------------------------------------------------- |
+| WHOOGLE_URL_PREFIX   | The URL prefix to use for the whoogle instance (i.e. "/whoogle")                          |
 | WHOOGLE_DOTENV       | Load environment variables in `whoogle.env`                                               |
 | WHOOGLE_USER         | The username for basic auth. WHOOGLE_PASS must also be set if used.                       |
 | WHOOGLE_PASS         | The password for basic auth. WHOOGLE_USER must also be set if used.                       |

--- a/app/filter.py
+++ b/app/filter.py
@@ -285,6 +285,11 @@ class Filter:
                 render_template('logo.html'),
                 features='html.parser'))
             return
+        elif src.startswith(G_M_LOGO_URL):
+            # Re-brand with single-letter Whoogle logo
+            element['src'] = 'static/img/favicon/apple-icon.png'
+            element.parent['href'] = 'home'
+            return
         elif src.startswith(GOOG_IMG) or GOOG_STATIC in src:
             element['src'] = BLANK_B64
             return
@@ -368,6 +373,10 @@ class Filter:
             # Internal google links (i.e. mail, maps, etc) should still
             # be forwarded to Google
             link['href'] = 'https://google.com' + q
+        elif q.startswith('https://accounts.google.com'):
+            # Remove Sign-in link
+            link.decompose()
+            return
         elif '/search?q=' in href:
             # "li:1" implies the query should be interpreted verbatim,
             # which is accomplished by wrapping the query in double quotes

--- a/app/filter.py
+++ b/app/filter.py
@@ -104,6 +104,8 @@ class Filter:
         input_form = soup.find('form')
         if input_form is not None:
             input_form['method'] = 'GET' if self.config.get_only else 'POST'
+            # Use a relative URI for submissions
+            input_form['action'] = 'search'
 
         # Ensure no extra scripts passed through
         for script in soup('script'):
@@ -394,6 +396,16 @@ class Filter:
             if href.startswith(MAPS_URL):
                 # Maps links don't work if a site filter is applied
                 link['href'] = MAPS_URL + "?q=" + clean_query(q)
+            elif href.startswith('/?') or href.startswith('/search?'):
+                # make sure that tags can be clicked as relative URLs
+                link['href'] = href[1:]
+            elif href.startswith('/intl/'):
+                # do nothing, keep original URL for ToS
+                pass
+            elif href.startswith('/preferences'):
+                # there is no config specific URL, remove this
+                link.decompose()
+                return
             else:
                 link['href'] = href
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -570,4 +570,7 @@ def run_app() -> None:
     elif args.unix_socket:
         waitress.serve(app, unix_socket=args.unix_socket)
     else:
-        waitress.serve(app, listen="{}:{}".format(args.host, args.port))
+        waitress.serve(
+            app,
+            listen="{}:{}".format(args.host, args.port),
+            url_prefix=os.environ.get('WHOOGLE_URL_PREFIX', ''))

--- a/app/static/js/utils.js
+++ b/app/static/js/utils.js
@@ -1,6 +1,10 @@
 const checkForTracking = () => {
     const mainDiv = document.getElementById("main");
-    const query = document.getElementById("search-bar").value.replace(/\s+/g, '');
+    const searchBar = document.getElementById("search-bar");
+    // some pages (e.g. images) do not have these
+    if (!mainDiv || !searchBar)
+        return;
+    const query = searchBar.value.replace(/\s+/g, '');
 
     // Note: regex functions for checking for tracking queries were derived
     // from here -- https://stackoverflow.com/questions/619977
@@ -59,11 +63,14 @@ document.addEventListener("DOMContentLoaded", function() {
     checkForTracking();
 
     // Clear input if reset button tapped
-    const search = document.getElementById("search-bar");
+    const searchBar = document.getElementById("search-bar");
     const resetBtn = document.getElementById("search-reset");
+    // some pages (e.g. images) do not have these
+    if (!searchBar || !resetBtn)
+        return;
     resetBtn.addEventListener("click", event => {
         event.preventDefault();
-        search.value = "";
-        search.focus();
+        searchBar.value = "";
+        searchBar.focus();
     });
 });

--- a/app/templates/search.html
+++ b/app/templates/search.html
@@ -1,4 +1,4 @@
-<form id="search-form" action="{{ url }}/search" method="post">
+<form id="search-form" action="search" method="post">
     <input
             type="text"
             name="q"

--- a/app/utils/results.py
+++ b/app/utils/results.py
@@ -10,6 +10,7 @@ import re
 SKIP_ARGS = ['ref_src', 'utm']
 SKIP_PREFIX = ['//www.', '//mobile.', '//m.']
 GOOG_STATIC = 'www.gstatic.com'
+G_M_LOGO_URL = 'https://www.gstatic.com/m/images/icons/googleg.gif'
 GOOG_IMG = '/images/branding/searchlogo/1x/googlelogo'
 LOGO_URL = GOOG_IMG + '_desk'
 BLANK_B64 = ('data:image/png;base64,'

--- a/charts/whoogle/values.yaml
+++ b/charts/whoogle/values.yaml
@@ -24,6 +24,7 @@ serviceAccount:
   name: ""
 
 conf: {}
+  # WHOOGLE_URL_PREFIX: ""   # The URL prefix to use for the whoogle instance (i.e. "/whoogle")
   # WHOOGLE_DOTENV: ""       # Load environment variables in whoogle.env
   # WHOOGLE_USER: ""         # The username for basic auth. WHOOGLE_PASS must also be set if used.
   # WHOOGLE_PASS: ""         # The password for basic auth. WHOOGLE_USER must also be set if used.

--- a/whoogle.template.env
+++ b/whoogle.template.env
@@ -24,6 +24,9 @@
 #WHOOGLE_CSP=1
 #HTTPS_ONLY=1
 
+# The URL prefix to use for the whoogle instance (i.e. "/whoogle")
+#WHOOGLE_URL_PREFIX=""
+
 # Restrict results to only those near a particular city
 #WHOOGLE_CONFIG_NEAR=denver
 


### PR DESCRIPTION
If you are running whoogle on a non-root URI (e.g. `/something/whoogle`) then results will not work.

This PR make some changes to the souped'up results so that URLs will be correctly relativised.

Fixes #441