### PR TITLE
Update translations.json

### DIFF
--- a/app/static/settings/translations.json
+++ b/app/static/settings/translations.json
@@ -133,7 +133,7 @@
         "images": "Bilder",
         "maps": "Maps",
         "videos": "Videos",
-        "news": "Nieuws",
+        "news": "Nachrichten",
         "books": "Bücher",
         "anon-view": "Anonyme Ansicht"
     },


### PR DESCRIPTION
Fixed Translation error in german
News means "Nachrichten"