### PR TITLE
Fix image view

### DIFF
--- a/app/filter.py
+++ b/app/filter.py
@@ -533,7 +533,7 @@ class Filter:
                 continue
 
             img_url = urlparse.unquote(urls[0].replace(
-                f'{Endpoint.imgres}?imgurl=', ''))
+                f'/{Endpoint.imgres}?imgurl=', ''))
 
             try:
                 # Try to strip out only the necessary part of the web page link


### PR DESCRIPTION
I previously removed the / without noticing it was part of a string replacement in #734 This caused the href of "View Image" contain a leading "/" which is wrong. This PR added it back.