### PR TITLE
Improve newtab

### DIFF
--- a/app/filter.py
+++ b/app/filter.py
@@ -462,8 +462,6 @@ class Filter:
                 self._av.add(netloc)
                 append_anon_view(link, self.config)
 
-            if self.config.new_tab:
-                link['target'] = '_blank'
         else:
             if href.startswith(MAPS_URL):
                 # Maps links don't work if a site filter is applied
@@ -481,6 +479,9 @@ class Filter:
                 return
             else:
                 link['href'] = href
+
+        if self.config.new_tab and (link['href'].startswith('http') or link['href'].startswith('imgres?')):
+            link['target'] = '_blank'
 
         # Replace link location if "alts" config is enabled
         if self.config.alts:

--- a/app/filter.py
+++ b/app/filter.py
@@ -480,8 +480,11 @@ class Filter:
             else:
                 link['href'] = href
 
-        if self.config.new_tab and (link['href'].startswith('http') or link['href'].startswith('imgres?')):
-            link['target'] = '_blank'
+        if self.config.new_tab and (
+            link["href"].startswith("http")
+            or link["href"].startswith("imgres?")
+        ):
+            link["target"] = "_blank"
 
         # Replace link location if "alts" config is enabled
         if self.config.alts:


### PR DESCRIPTION
The majority of image links and links that are not handle by whoogle are not opening in new tabs, this allow links that are not related to the application to open in new tabs.