### PR TITLE
Fixes handling of maps

### DIFF
--- a/app/filter.py
+++ b/app/filter.py
@@ -36,6 +36,28 @@ def extract_q(q_str: str, href: str) -> str:
     return parse_qs(q_str)['q'][0] if ('&q=' in href or '?q=' in href) else ''
 
 
+def build_map_url(href: str) -> str:
+    """Tries to extract known args that explain the location in the url. If a
+    location is found, returns the default url with it. Otherwise, returns the
+    url unchanged.
+
+    Args:
+        href: The full url to check.
+
+    Returns:
+        str: The parsed url, or the url unchanged.
+    """
+    # parse the url
+    parsed_url = parse_qs(href)
+    # iterate through the known parameters and try build the url
+    for param in MAPS_ARGS:
+        if param in parsed_url:
+            return MAPS_URL + "?q=" + parsed_url[param][0]
+
+    # query could not be extracted returning unchanged url
+    return href
+
+
 def clean_query(query: str) -> str:
     """Strips the blocked site list from the query, if one is being
     used.
@@ -467,7 +489,7 @@ class Filter:
         else:
             if href.startswith(MAPS_URL):
                 # Maps links don't work if a site filter is applied
-                link['href'] = MAPS_URL + "?q=" + clean_query(q)
+                link['href'] = build_map_url(link['href'])
             elif (href.startswith('/?') or href.startswith('/search?') or
                   href.startswith('/imgres?')):
                 # make sure that tags can be clicked as relative URLs

--- a/app/utils/results.py
+++ b/app/utils/results.py
@@ -18,6 +18,7 @@ LOGO_URL = GOOG_IMG + '_desk'
 BLANK_B64 = ('data:image/png;base64,'
              'iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAQAAAAnOwc2AAAAD0lEQVR42mNkw'
              'AIYh7IgAAVVAAuInjI5AAAAAElFTkSuQmCC')
+MAPS_ARGS = ['q', 'daddr']
 
 # Ad keywords
 BLACKLIST = [


### PR DESCRIPTION
When there is no q parameter in google maps, the directions url in search results points to an empty location.

This workaround fixes it by looking for other parameters that explain the location, if none is found it returns the true url.