### PR TITLE
Use X-Forwarded-Host as url_root when present

### DIFF
--- a/app/utils/misc.py
+++ b/app/utils/misc.py
@@ -35,6 +35,15 @@ def get_request_url(url: str) -> str:
     return url
 
 
+def get_proxy_host_url(r: Request, default: str) -> str:
+    scheme = r.headers.get('X-Forwarded-Proto', 'http')
+    http_host = r.headers.get('X-Forwarded-Host')
+    if http_host:
+        return f'{scheme}://{http_host}/'
+
+    return default
+
+
 def check_for_update(version_url: str, current: str) -> int:
     # Check for the latest version of Whoogle
     try:

--- a/app/utils/search.py
+++ b/app/utils/search.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from app.filter import Filter
 from app.request import gen_query
+from app.utils.misc import get_proxy_host_url
 from app.utils.results import get_first_link
 from bs4 import BeautifulSoup as bsoup
 from cryptography.fernet import Fernet, InvalidToken
@@ -115,10 +116,8 @@ class Search:
 
         """
         mobile = 'Android' in self.user_agent or 'iPhone' in self.user_agent
-
-        # reconstruct url_root if X-Forwarded-Host header present
-        scheme = self.request.headers.get('X-Forwarded-Proto', 'http')
-        http_host = self.request.headers.get('X-Forwarded-Host')
+        # reconstruct url if X-Forwarded-Host header present
+        root_url = get_proxy_host_url(self.request, self.request.url_root)
         if http_host:
             root_url = f'{scheme}://{http_host}/'
         else:

--- a/app/utils/search.py
+++ b/app/utils/search.py
@@ -116,6 +116,14 @@ class Search:
         """
         mobile = 'Android' in self.user_agent or 'iPhone' in self.user_agent
 
+        # reconstruct url_root if X-Forwarded-Host header present
+        scheme = self.request.headers.get('X-Forwarded-Proto', 'http')
+        http_host = self.request.headers.get('X-Forwarded-Host')
+        if http_host:
+            root_url = f'{scheme}://{http_host}/'
+        else:
+            root_url = self.request.url_root
+
         content_filter = Filter(self.session_key,
                                 root_url=self.request.url_root,
                                 mobile=mobile,

--- a/app/utils/search.py
+++ b/app/utils/search.py
@@ -118,6 +118,7 @@ class Search:
         mobile = 'Android' in self.user_agent or 'iPhone' in self.user_agent
         # reconstruct url if X-Forwarded-Host header present
         root_url = get_proxy_host_url(self.request, self.request.url_root)
+        
         content_filter = Filter(self.session_key,
                                 root_url=root_url,
                                 mobile=mobile,

--- a/app/utils/search.py
+++ b/app/utils/search.py
@@ -118,7 +118,7 @@ class Search:
         mobile = 'Android' in self.user_agent or 'iPhone' in self.user_agent
         # reconstruct url if X-Forwarded-Host header present
         root_url = get_proxy_host_url(self.request, self.request.url_root)
-        
+
         content_filter = Filter(self.session_key,
                                 root_url=root_url,
                                 mobile=mobile,

--- a/app/utils/search.py
+++ b/app/utils/search.py
@@ -118,11 +118,6 @@ class Search:
         mobile = 'Android' in self.user_agent or 'iPhone' in self.user_agent
         # reconstruct url if X-Forwarded-Host header present
         root_url = get_proxy_host_url(self.request, self.request.url_root)
-        if http_host:
-            root_url = f'{scheme}://{http_host}/'
-        else:
-            root_url = self.request.url_root
-
         content_filter = Filter(self.session_key,
                                 root_url=root_url,
                                 mobile=mobile,

--- a/app/utils/search.py
+++ b/app/utils/search.py
@@ -125,7 +125,7 @@ class Search:
             root_url = self.request.url_root
 
         content_filter = Filter(self.session_key,
-                                root_url=self.request.url_root,
+                                root_url=root_url,
                                 mobile=mobile,
                                 config=self.config,
                                 query=self.query)


### PR DESCRIPTION
If whoogle is behind a proxy which is accessed on a non-standard port, this port is lost to the application and `element['src']`s are incorrectly formed (omitting port). The port is also missing when redirecting after new session.

E.g. some unrelated service is running on example.com:80/443 and Nginx listens on example.com:5000 proxying to whoogle which listens on some host 5001. In this case, `request.url_root` doesn't include the front port 5000 which is expected by the client (browser) to render `img.src` correctly.

HTTP X-Forwarded-Host will contain this front port number in a typical Nginx reverse proxy configuratoin, e.g.

```nginx
server {
    listen 5000;
    listen [::]:5000;
    server_name whoogle.example.com;
    ...
    location ~ /(search|) {
            proxy_pass http://10.0.8.14:5001;
            proxy_set_header Host $host;
            proxy_set_header X-Forwarded-Host $http_host; # will forward https://whoogle.example.com:5000/
            proxy_set_header X-Forwarded-Proto $scheme;
            proxy_redirect off;
    }
}
```
