### PR TITLE
Tor password newline fix

### DIFF
--- a/app/request.py
+++ b/app/request.py
@@ -56,7 +56,7 @@ def send_tor_signal(signal: Signal) -> bool:
                     # Scan for the last line of the file.
                     for line in conf:
                         pass
-                    secret = line
+                    secret = line.strip('\n')
                 authenticate_password(c, password=secret)
             else:
                 cookie_path = '/var/lib/tor/control_auth_cookie'

--- a/app/request.py
+++ b/app/request.py
@@ -56,7 +56,9 @@ def send_tor_signal(signal: Signal) -> bool:
                     # Scan for the last line of the file.
                     for line in conf:
                         pass
-                    secret = line.strip('\n')
+                    secret = line
+                    if ( '\n' in line ):
+                        secret = line.strip('\n')
                 authenticate_password(c, password=secret)
             else:
                 cookie_path = '/var/lib/tor/control_auth_cookie'

--- a/app/request.py
+++ b/app/request.py
@@ -56,9 +56,7 @@ def send_tor_signal(signal: Signal) -> bool:
                     # Scan for the last line of the file.
                     for line in conf:
                         pass
-                    secret = line
-                    if '\n' in line:
-                        secret = line.strip('\n')
+                    secret = line.strip('\n')
                 authenticate_password(c, password=secret)
             else:
                 cookie_path = '/var/lib/tor/control_auth_cookie'

--- a/app/request.py
+++ b/app/request.py
@@ -57,7 +57,7 @@ def send_tor_signal(signal: Signal) -> bool:
                     for line in conf:
                         pass
                     secret = line
-                    if ( '\n' in line ):
+                    if '\n' in line:
                         secret = line.strip('\n')
                 authenticate_password(c, password=secret)
             else:


### PR DESCRIPTION
Sometimes a newline character is picked up when parsing control.conf. So just strip it when we encounter it.