### PR TITLE
Removal of search.wef.lol

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,7 +597,6 @@ A lot of the app currently piggybacks on Google's existing support for fetching 
 | [https://gowogle.voring.me](https://gowogle.voring.me) | 🇺🇸 US | Multi-choice | |
 | [https://whoogle.lunar.icu](https://whoogle.lunar.icu) | 🇩🇪 DE | Multi-choice | ✅ |
 | [https://whoogle.privacydev.net](https://whoogle.privacydev.net) | 🇺🇸 US | Multi-choice | |
-| [https://search.wef.lol](https://search.wef.lol) | 🇮🇸 IC | Multi-choice | |
 | [https://wg.vern.cc](https://wg.vern.cc) | 🇺🇸 US | English |  |
 
 

--- a/misc/instances.txt
+++ b/misc/instances.txt
@@ -10,4 +10,3 @@ https://whoogle.dcs0.hu
 https://whoogle.esmailelbob.xyz
 https://whoogle.lunar.icu
 https://whoogle.privacydev.net
-https://search.wef.lol


### PR DESCRIPTION
search.wef.lol is redirecting to a sketchy site `https://affordableluxurybags[.]nu/`