### PR TITLE
Fix color for light contrast text

### DIFF
--- a/app/static/css/variables.css
+++ b/app/static/css/variables.css
@@ -5,7 +5,7 @@
     --whoogle-page-bg: #ffffff;
     --whoogle-element-bg: #4285f4;
     --whoogle-text: #000000;
-    --whoogle-contrast-text: #ffffff;
+    --whoogle-contrast-text: #70757a;
     --whoogle-secondary-text: #70757a;
     --whoogle-result-bg: #ffffff;
     --whoogle-result-title: #1967d2;


### PR DESCRIPTION
The color for the variable whoogle-contrast-text should be black or gray; otherwise it will not be shown with white background. 