### PR TITLE
Include new ad filter keyword

### DIFF
--- a/app/utils/results.py
+++ b/app/utils/results.py
@@ -25,7 +25,7 @@ BLACKLIST = [
     'Reklama', 'Реклама', 'Anunț', '광고', 'annons', 'Annonse', 'Iklan',
     '広告', 'Augl.', 'Mainos', 'Advertentie', 'إعلان', 'Գովազդ', 'विज्ञापन',
     'Reklam', 'آگهی', 'Reklāma', 'Reklaam', 'Διαφήμιση', 'מודעה', 'Hirdetés',
-    'Anúncio', 'Quảng cáo','โฆษณา', 'sponsored'
+    'Anúncio', 'Quảng cáo','โฆษณา', 'sponsored', 'patrocinado'
 ]
 
 SITE_ALTS = {


### PR DESCRIPTION
Hello, this new keyword will help recognizing more sponsored search results:

![Sponsored result](https://user-images.githubusercontent.com/22637294/200090552-67a33fe2-e110-4c88-914d-a8e96db04b40.jpg)

This search was made from my private instance which is in Spain and uses Spanish language.

By the way, congratulations for this awesome project!