### PR TITLE
Fix: added a functionality to make sure escaped characters stay escaped.

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -284,7 +284,6 @@ def autocomplete():
         g.user_request.autocomplete(q) if not g.user_config.tor else []
     ])
 
-
 @app.route(f'/{Endpoint.search}', methods=['GET', 'POST'])
 @session_required
 @auth_required
@@ -323,6 +322,7 @@ def search():
     soup = bsoup(response, "html.parser");
     for x in soup.find_all(attrs={"id": "st-card"}):
         x.replace_with("")
+
     response = str(soup)
 
     # Return 503 if temporarily blocked by captcha
@@ -336,6 +336,7 @@ def search():
             config=g.user_config,
             query=urlparse.unquote(query),
             params=g.user_config.to_params(keys=['preferences'])), 503
+
     response = bold_search_terms(response, query)
 
     # Feature to display IP address
@@ -358,6 +359,7 @@ def search():
 
     preferences = g.user_config.preferences
     home_url = f"home?preferences={preferences}" if preferences else "home"
+    cleanresponse = str(response).replace("andlt;","&lt;").replace("andgt;","&gt;")
 
     return render_template(
         'display.html',
@@ -378,7 +380,7 @@ def search():
         is_translation=any(
             _ in query.lower() for _ in [translation['translate'], 'translate']
         ) and not search_util.search_type,  # Standard search queries only
-        response=response,
+        response=cleanresponse,
         version_number=app.config['VERSION_NUMBER'],
         search_header=render_template(
             'header.html',

--- a/app/utils/search.py
+++ b/app/utils/search.py
@@ -1,7 +1,6 @@
 import os
 import re
 from typing import Any
-
 from app.filter import Filter
 from app.request import gen_query
 from app.utils.misc import get_proxy_host_url
@@ -142,7 +141,8 @@ class Search:
                                        force_mobile=view_image)
 
         # Produce cleanable html soup from response
-        html_soup = bsoup(get_body.text, 'html.parser')
+        get_body_safed = get_body.text.replace("&lt;","andlt;").replace("&gt;","andgt;")
+        html_soup = bsoup(get_body_safed, 'html.parser')
 
         # Replace current soup if view_image is active
         if view_image:


### PR DESCRIPTION
This PR is linked to the issue #908 which shows that, basically, Whoogle results render html characters unescaped. Here's a screenshot as referenced in the issue:

![image](https://user-images.githubusercontent.com/22837764/209409123-bccd7136-72a2-46b8-bd55-c9c39bbf4680.png)

After checking, I found out that several points: 
+ the characters inside the `<div>` content tag from the search results (`getbody.text` in search.py) are already escaped, with `"<"` and `">"` characters converted into `"&lt;"` and `"&gt;"`, respectively
+ however, because the `getbody.text` then passed through several `bsoup` class, the escaped tag characters became unescaped.

To prevent this, I replaced `"&lt;"` and `"&gt;"` with `"andlt;"` and `"andgt;"`, respectively. This way, when the 'response' object get loaded to `bsoup` (which happens several times throughout the process between search.py and routes.py), `bsoup` will not unescape them. Finally, at the end, before the `responses` object sent to the `render_template` in `routes.py`, I simply replaced the `"andlt;"` and `"andgt;"` back to `"&lt;"` and `"&gt;"`.

Here's the screenshot from the search result on Whoogle following this fix:

![screenshot-localhost_5000-2022 12 23-22_58_09](https://user-images.githubusercontent.com/22837764/209409436-c7f02e69-f4ed-44b7-9f10-93d9f566a9f1.png)

