### PR TITLE
adding line break between header options

### DIFF
--- a/app/templates/header.html
+++ b/app/templates/header.html
@@ -136,6 +136,7 @@
                 </option>
             {% endfor %}
         </select>
+        <br />
         <label for="config-time-period">{{ translation['config-time-period'] }}: </label>
         <select name="tbs" id="result-time-period">
             {% for time_period in time_periods %}


### PR DESCRIPTION
Reason for this is because on mobile view, "Time Period:" shows up on a separate line from its dropdown