### PR TITLE
Don't prepend services that have schemes with '//'

### DIFF
--- a/app/utils/results.py
+++ b/app/utils/results.py
@@ -171,7 +171,10 @@ def get_site_alt(link: str) -> str:
             link = '//'.join(link.split('//')[1:])
 
         for prefix in SKIP_PREFIX:
-            link = link.replace(prefix, '//')
+            if parsed_alt.scheme:
+                link = link.replace(prefix, '')
+            else:
+                link = link.replace(prefix, '//')
         break
 
     return link


### PR DESCRIPTION
This caused issues with hitting some of my local services; despite the URL being correctly configured, the prepended '//' would cause some URLs to work incorrectly. Tested with both https:// and http://-prefixed alt sites.