### PR TITLE
Add a function to check if target_word contains CJK characters

### DIFF
--- a/app/utils/results.py
+++ b/app/utils/results.py
@@ -44,6 +44,28 @@ SITE_ALTS = {
 }
 
 
+def contains_cjko(s: str) -> bool:
+    """This function check whether or not a string contains Chinese, Japanese,
+    or Korean characters. It employs regex and uses the u escape sequence to
+    match any character in the following Unicode ranges:
+    - 4e00-9fff: Chinese characters
+    - 3040-309f: Japanese hiragana
+    - 30a0-30ff: Japanese katakana
+    - 4e00-9faf: Japanese kanji
+    - ac00-d7af: Korean hangul syllables
+    - 1100-11ff: Korean hangul jamo
+
+    Args:
+        s (str): string to be checked
+
+    Returns:
+        bool: True if the input s contains the characters and False otherwise
+    """
+    return bool(
+        re.search(
+            r'[\u4e00-\u9fff\u3040-\u309f\u30a0-\u30ff\u4e00-\u9faf\uac00-\ud7af\u1100-\u11ff]', s))
+
+
 def bold_search_terms(response: str, query: str) -> BeautifulSoup:
     """Wraps all search terms in bold tags (<b>). If any terms are wrapped
     in quotes, only that exact phrase will be made bold.
@@ -66,12 +88,18 @@ def bold_search_terms(response: str, query: str) -> BeautifulSoup:
         # Ensure target word is escaped for regex
         target_word = re.escape(target_word)
 
+        # Check if the word contains Chinese, Japanese, or Korean characters
+        if contains_cjko(target_word):
+            reg_pattern = fr'((?![{{}}<>-]){target_word}(?![{{}}<>-]))'
+        else:
+            reg_pattern = fr'\b((?![{{}}<>-]){target_word}(?![{{}}<>-]))\b'
+
         if re.match('.*[@_!#$%^&*()<>?/\|}{~:].*', target_word) or (
                 element.parent and element.parent.name == 'style'):
             return
 
         element.replace_with(BeautifulSoup(
-            re.sub(fr'\b((?![{{}}<>-]){target_word}(?![{{}}<>-]))\b',
+            re.sub(reg_pattern,
                    r'<b>\1</b>',
                    element,
                    flags=re.I), 'html.parser')

--- a/app/utils/results.py
+++ b/app/utils/results.py
@@ -47,13 +47,7 @@ SITE_ALTS = {
 def contains_cjko(s: str) -> bool:
     """This function check whether or not a string contains Chinese, Japanese,
     or Korean characters. It employs regex and uses the u escape sequence to
-    match any character in the following Unicode ranges:
-    - 4e00-9fff: Chinese characters
-    - 3040-309f: Japanese hiragana
-    - 30a0-30ff: Japanese katakana
-    - 4e00-9faf: Japanese kanji
-    - ac00-d7af: Korean hangul syllables
-    - 1100-11ff: Korean hangul jamo
+    match any character in a set of Unicode ranges.
 
     Args:
         s (str): string to be checked
@@ -61,9 +55,14 @@ def contains_cjko(s: str) -> bool:
     Returns:
         bool: True if the input s contains the characters and False otherwise
     """
-    return bool(
-        re.search(
-            r'[\u4e00-\u9fff\u3040-\u309f\u30a0-\u30ff\u4e00-\u9faf\uac00-\ud7af\u1100-\u11ff]', s))
+    unicode_ranges = ('\u4e00-\u9fff' # Chinese characters
+                      '\u3040-\u309f' # Japanese hiragana
+                      '\u30a0-\u30ff' # Japanese katakana
+                      '\u4e00-\u9faf' # Japanese kanji
+                      '\uac00-\ud7af' # Korean hangul syllables
+                      '\u1100-\u11ff' # Korean hangul jamo
+                      )
+    return bool(re.search(fr'[{unicode_ranges}]', s))
 
 
 def bold_search_terms(response: str, query: str) -> BeautifulSoup:


### PR DESCRIPTION
This PR is linked to Issue #904 which shows that Whoogle results do not render bold all of target words if they are Chinese characters.

Further investigations show similar behavior for Japanese (hiragana, katakana, kanji), and Korean (hangul syllables, hangul jamo) characters: not all of the words displayed on the result page are bolded.

To handle this, a function was added to check if `target_word` in `bold_search_terms.replace_any_case` contains Chinese, Korean, or Japanese characters and apply the regex that doesn't check for whitespace. This way, each search term would be bolded differently.

Screenshots of the search results after the commits linked to this PR:

![screenshot-localhost_5000-2023 01 08-23_12_08](https://user-images.githubusercontent.com/22837764/211222505-0d9a7a2c-8adf-4447-a6f5-db104e008d51.png)

![screenshot-localhost_5000-2023 01 08-23_14_26](https://user-images.githubusercontent.com/22837764/211222511-588fa4a3-82b4-43a0-ac5f-507ac9d14613.png)

![screenshot-localhost_5000-2023 01 08-23_17_20](https://user-images.githubusercontent.com/22837764/211222520-b6bbf13c-1815-459f-b9c4-6e25d2789816.png)


