### PR TITLE
Fix a bug on remove_block_titles() and remove_block_url()

### DIFF
--- a/app/filter.py
+++ b/app/filter.py
@@ -225,7 +225,7 @@ class Filter:
     def remove_block_titles(self) -> None:
         if not self.main_divs or not self.config.block_title:
             return
-        block_title = re.compile(self.block_title)
+        block_title = re.compile(self.config.block_title)
         for div in [_ for _ in self.main_divs.find_all('div', recursive=True)]:
             block_divs = [_ for _ in div.find_all('h3', recursive=True)
                           if block_title.search(_.text) is not None]
@@ -234,7 +234,7 @@ class Filter:
     def remove_block_url(self) -> None:
         if not self.main_divs or not self.config.block_url:
             return
-        block_url = re.compile(self.block_url)
+        block_url = re.compile(self.config.block_url)
         for div in [_ for _ in self.main_divs.find_all('div', recursive=True)]:
             block_divs = [_ for _ in div.find_all('a', recursive=True)
                           if block_url.search(_.attrs['href']) is not None]


### PR DESCRIPTION
Fix the exception `AttributeError: 'Filter' object has no attribute 'block_url'` introduced in this commit [1].

`self.block_title` and `self.block_url` were members of the Filter object[2], but not anymore after commit [1].

This bug can be reproduced with setting `WHOOGLE_CONFIG_BLOCK_URL` to a non-empty string.

[1] https://github.com/benbusby/whoogle-search/commit/10a15e06e1bf6f1a22d1625950d8c221d99d6a07
[2] https://github.com/benbusby/whoogle-search/commit/284a8102c85bdc69674952bc30a6cfacfb8b01ee