### PR TITLE
Fix: keep blank values as True to handle blank 'q' input.

### DIFF
--- a/app/filter.py
+++ b/app/filter.py
@@ -44,7 +44,7 @@ def extract_q(q_str: str, href: str) -> str:
     Returns:
         str: The 'q' element of the link, or an empty string
     """
-    return parse_qs(q_str)['q'][0] if ('&q=' in href or '?q=' in href) else ''
+    return parse_qs(q_str, keep_blank_values=True)['q'][0] if ('&q=' in href or '?q=' in href) else ''
 
 
 def build_map_url(href: str) -> str:


### PR DESCRIPTION
This PR fixes (potentially) Issue #1050. 

Location of the bug found at the function:

```python
#app/filter.py

def extract_q(q_str: str, href: str) -> str:
    """Extracts the 'q' element from a result link. This is typically
    either the link to a result's website, or a string.

    Args:
        q_str: The result link to parse
        href: The full url to check for standalone 'q' elements first,
              rather than parsing the whole query string and then checking.

    Returns:
        str: The 'q' element of the link, or an empty string
    """

    return parse_qs(q_str)['q'][0] if ('&q=' in href or '?q=' in href) else ''
```

What happened when searching the query “Mathias Normann” (and potentially could be other queries) is that the `href` contains `"q"` but the value is blank in both `href` and `q_str` as follows:

```python
# href:
"/search?safe=off&sca_esv=556514156&gbv=1&q=&si=ACFMAn9guiESjt..."

# q_str:
"safe=off&sca_esv=556514156&gbv=1&q=&si=ACFMAn9guiESjt..."
```

Thus, the value of ‘q’ would be blank.

By default, the function `parse_qs` will not keep the blank values nor keys, thus making the resulting `parse_qs(q_str)['q'][0]` throwing a `KeyError` because the key ‘q’ is simply not there.

To fix this, I simply put the `keep_blank_values` parameter of the `parse_qs` function into `True`. This fixes the problem.

Some screenshots:

![image](https://github.com/benbusby/whoogle-search/assets/22837764/1b6c5877-c684-47c6-8218-ba60be8d7378)

![image](https://github.com/benbusby/whoogle-search/assets/22837764/165e442d-ce5d-45a6-8e31-17ce86a20bea)

Open to discussions and modifications if needed.