### PR TITLE
Helm chart fix: Provide auth in probes if it is set

### DIFF
--- a/charts/whoogle/templates/deployment.yaml
+++ b/charts/whoogle/templates/deployment.yaml
@@ -52,10 +52,20 @@ spec:
             httpGet:
               path: /
               port: http
+              {{- if and .Values.conf.WHOOGLE_USER .Values.conf.WHOOGLE_PASS }}
+              httpHeaders:
+                - name: Authorization
+                  value: Basic {{ b64enc (printf "%s:%s" .Values.conf.WHOOGLE_USER .Values.conf.WHOOGLE_PASS) }}
+              {{- end }}
           readinessProbe:
             httpGet:
               path: /
               port: http
+              {{- if and .Values.conf.WHOOGLE_USER .Values.conf.WHOOGLE_PASS }}
+              httpHeaders:
+                - name: Authorization
+                  value: Basic {{ b64enc (printf "%s:%s" .Values.conf.WHOOGLE_USER .Values.conf.WHOOGLE_PASS) }}
+              {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}


### PR DESCRIPTION
If the auth is set, the probes fail with a 401 error.