### PR TITLE
fix: add missing dependency `validators` to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ install_requires=
     python-dotenv
     requests
     stem
+    validators
     waitress
 
 [options.extras_require]


### PR DESCRIPTION
close #1086