### PR TITLE
Updating ad filter with Czech language version

### DIFF
--- a/app/utils/results.py
+++ b/app/utils/results.py
@@ -27,7 +27,8 @@ BLACKLIST = [
     'Reklama', 'Реклама', 'Anunț', '광고', 'annons', 'Annonse', 'Iklan',
     '広告', 'Augl.', 'Mainos', 'Advertentie', 'إعلان', 'Գովազդ', 'विज्ञापन',
     'Reklam', 'آگهی', 'Reklāma', 'Reklaam', 'Διαφήμιση', 'מודעה', 'Hirdetés',
-    'Anúncio', 'Quảng cáo','โฆษณา', 'sponsored', 'patrocinado', 'gesponsert'
+    'Anúncio', 'Quảng cáo', 'โฆษณา', 'sponsored', 'patrocinado', 'gesponsert', 
+    'Sponzorováno'
 ]
 
 SITE_ALTS = {


### PR DESCRIPTION
If your version of Google is in Czech language, commercial links will not be filtered out because the word 'Sponzorováno' is missing in Ad keywords list BLACKLIST.