### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -596,6 +596,7 @@ server {
 	    proxy_set_header X-Forwarded-Proto $scheme;
 	    proxy_set_header Host $host;
 	    proxy_set_header X-NginX-Proxy true;
+	    proxy_set_header X-Forwarded-Host $http_host;
 	    proxy_pass http://localhost:5000;
 	}
 }


### PR DESCRIPTION
Added X-Forwarded-Host to the nginx reverse proxy options as it's used in the code (app/utils/misc.py - line 84)

If X-Forwarded-Host is not set and the app is running behind nginx on any ports other than 80/433, then the port number in the URL returned by `get_proxy_host_url` function will be ignored

I'm running the Whoogle behind nginx reverse proxy on port 2053, The images were not displayed for me because url of images was `https://mydomain.com/element?...` instead of `https://mydomain.com:2053/element?...`.  After checking the code I was able to resolve it by adding `proxy_set_header X-Forwarded-Host $http_host;` to my nginx config file