### PR TITLE
Add ability to set custom dotenv path

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,6 +413,7 @@ There are a few optional environment variables available for customizing a Whoog
 | -------------------- | ----------------------------------------------------------------------------------------- |
 | WHOOGLE_URL_PREFIX   | The URL prefix to use for the whoogle instance (i.e. "/whoogle")                          |
 | WHOOGLE_DOTENV       | Load environment variables in `whoogle.env`                                               |
+| WHOOGLE_DOTENV_PATH  | The path to `whoogle.env` if not in default location                                      |
 | WHOOGLE_USER         | The username for basic auth. WHOOGLE_PASS must also be set if used.                       |
 | WHOOGLE_PASS         | The password for basic auth. WHOOGLE_USER must also be set if used.                       |
 | WHOOGLE_PROXY_USER   | The username of the proxy server.                                                         |

--- a/README.md
+++ b/README.md
@@ -241,6 +241,8 @@ Description=Whoogle
 #Environment=WHOOGLE_ALT_SO=farside.link/anonymousoverflow
 # Load values from dotenv only
 #Environment=WHOOGLE_DOTENV=1
+# specify dotenv location if not in default location
+#Environment=WHOOGLE_DOTENV_PATH=<path/to>/whoogle.env
 Type=simple
 User=<username>
 # If installed as a package, add:

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -25,9 +25,10 @@ app = Flask(__name__, static_folder=os.path.dirname(
 
 app.wsgi_app = ProxyFix(app.wsgi_app)
 
-dot_env_path = (
-    os.path.join(os.path.dirname(os.path.abspath(__file__)),
-    '../whoogle.env'))
+# look for WHOOGLE_ENV, else look in parent directory
+dot_env_path = os.getenv(
+    "WHOOGLE_DOTENV_PATH",
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "../whoogle.env"))
 
 # Load .env file if enabled
 if os.path.exists(dot_env_path):


### PR DESCRIPTION
Recently, I installed the project via `pipx` in combination with a dotenv file for the config as a  systemd service. However, the default (and hardcoded) location of the dotenv is the parent directory of the app, which makes sense if the app sits in the repo's directory. When installing with pipx though, one would need to put the dotenv file into the `site-packages` directory which doesn't seem sensible, even if harmless. As such, I thought it would make sense to allow setting a custom path to the dotenv (something like `~/.config/whoogle/whoogle.env`), which this change allows by passing .env's path to  the environment variable `WHOOGLE_DOTENV_PATH` while defaulting to the current behavior