### PR TITLE
Allow to define fallback Search Engine URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,7 @@ There are a few optional environment variables available for customizing a Whoog
 | WHOOGLE_TOR_CONF | The absolute path to the config file containing the password for the tor control port. Default: ./misc/tor/control.conf WHOOGLE_TOR_PASS must be 1 for this to work.|
 | WHOOGLE_SHOW_FAVICONS | Show/hide favicons next to search result URLs. Default on.                               |
 | WHOOGLE_UPDATE_CHECK  | Enable/disable the automatic daily check for new versions of Whoogle. Default on.        |
+| WHOOGLE_FALLBACK_ENGINE_URL | Set a fallback Search Engine URL when there is internal server error or instance is rate-limited. Search query is appended to the end of the URL (eg. https://duckduckgo.com/?k1=-1&q=). |
 
 ### Config Environment Variables
 These environment variables allow setting default config values, but can be overwritten manually by using the home page config menu. These allow a shortcut for destroying/rebuilding an instance to the same config state every time.

--- a/app/routes.py
+++ b/app/routes.py
@@ -339,6 +339,10 @@ def search():
     # Return 503 if temporarily blocked by captcha
     if has_captcha(str(response)):
         app.logger.error('503 (CAPTCHA)')
+        fallback_engine = os.environ.get('WHOOGLE_FALLBACK_ENGINE_URL', '')
+        if (fallback_engine):
+            return redirect(fallback_engine + query)
+        
         return render_template(
             'error.html',
             blocked=True,
@@ -618,6 +622,10 @@ def internal_error(e):
         pass
 
     print(traceback.format_exc(), file=sys.stderr)
+
+    fallback_engine = os.environ.get('WHOOGLE_FALLBACK_ENGINE_URL', '')
+    if (fallback_engine):
+        return redirect(fallback_engine + query)
 
     localization_lang = g.user_config.get_localization_lang()
     translation = app.config['TRANSLATIONS'][localization_lang]


### PR DESCRIPTION
Allow to define fallback Search Engine URL when there is internal server error or instance is rate-limited. Search query is appended to the end of the URL (eg. https://duckduckgo.com/?k1=-1&q=).