### PR TITLE
USPS tracking link produces a blank white screen on (Android) mobile

### DIFF
--- a/app/static/js/utils.js
+++ b/app/static/js/utils.js
@@ -16,7 +16,7 @@ const checkForTracking = () => {
             ]
         },
         "usps": {
-            "link": `https://tools.usps.com/go/TrackConfirmAction?tLabels=${query}`,
+            "link": `https://tools.usps.com/go/TrackConfirmAction_input?origTrackNum=${query}`,
             "expr": [
                 /(\b\d{30}\b)|(\b91\d+\b)|(\b\d{20}\b)/,
                 /^E\D{1}\d{9}\D{2}$|^9\d{15,21}$/,


### PR DESCRIPTION
On my Pixel 7 with Firefox and Chrome, the current USPS tracking link results in a blank white page. This alternate USPS tracking link works as expected on mobile (and desktop).

Reported elsewhere:
- https://old.reddit.com/r/EtsySellers/comments/1akwyfo/anyone_having_issues_with_usps_tracking/
- https://forums.collectors.com/discussion/1101104/fyi-usps-tracking-blank-screen-fix