### PR TITLE
Ensure helm chart can run on Kubernetes >= `v1.25` and improve installation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,7 +389,7 @@ To use the Kubernetes Helm Chart:
 1. Ensure you have [Helm](https://helm.sh/docs/intro/install/) `>=3.0.0` installed
 2. Clone this repository
 3. Update [charts/whoogle/values.yaml](./charts/whoogle/values.yaml) as desired
-4. Run `helm install whoogle ./charts/whoogle`
+4. Run `helm upgrade --install whoogle ./charts/whoogle`
 
 ___
 

--- a/charts/whoogle/templates/hpa.yaml
+++ b/charts/whoogle/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-{{- if semverCompare ">=1.25-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.23-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: autoscaling/v2
 {{- else -}}
 apiVersion: autoscaling/v2beta1
@@ -21,7 +21,7 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        {{- if semverCompare ">=1.25-0" .Capabilities.KubeVersion.GitVersion }}
+        {{- if semverCompare ">=1.23-0" .Capabilities.KubeVersion.GitVersion }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
@@ -33,7 +33,7 @@ spec:
     - type: Resource
       resource:
         name: memory
-        {{- if semverCompare ">=1.25-0" .Capabilities.KubeVersion.GitVersion }}
+        {{- if semverCompare ">=1.23-0" .Capabilities.KubeVersion.GitVersion }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}

--- a/charts/whoogle/templates/hpa.yaml
+++ b/charts/whoogle/templates/hpa.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.autoscaling.enabled }}
+{{- if semverCompare ">=1.25-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: autoscaling/v2
+{{- else -}}
 apiVersion: autoscaling/v2beta1
+{{- end }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "whoogle.fullname" . }}
@@ -17,12 +21,24 @@ spec:
     - type: Resource
       resource:
         name: cpu
+        {{- if semverCompare ">=1.25-0" .Capabilities.KubeVersion.GitVersion }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+        {{- else -}}
         targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+        {{- end }}
     {{- end }}
     {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
+        {{- if semverCompare ">=1.25-0" .Capabilities.KubeVersion.GitVersion }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+        {{- else -}}
         targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+        {{- end }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
**Proposed changes:**
1. Replace `helm install` with `helm upgrade --install`, which can be used on both initial installation and upgradation scenarios.
2. Migrate old API to the latest API and add compatibility with old API: `autoscaling/v2beta1`

**Supporting point:**
- It is easier to use if using `helm upgrade --install`
- "The autoscaling/v2beta1 API version of HorizontalPodAutoscaler is no longer served as of v1.25." (src: [Deprecated API Migration Guide - v1.25 - HorizontalPodAutoscaler](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#horizontalpodautoscaler-v125)) Meantime, `v1.24` is **EOL** 16 months ago. (src: [Non-Active Branch history](https://kubernetes.io/releases/patch-releases/#non-active-branch-history)) 
Today if we are using current version of helm chart, it will fail to run if HPA is enabled as the old API is being deleted since `v1.25`.
  ```bash
  joey [ ~/whoogle-search ]$ helm upgrade --install whoogle ./charts/whoogle
  Error: UPGRADE FAILED: resource mapping not found for name: "whoogle" namespace: "" from "": no matches for kind "HorizontalPodAutoscaler" in version "autoscaling/v2beta1"
  ensure CRDs are installed first
  ```
- Make `autoscaling/v2` targeting `v1.23` as `autoscaling/v2` is available since `v1.23`.