### PR TITLE
fix duckduckgo search parameter

### DIFF
--- a/app/templates/error.html
+++ b/app/templates/error.html
@@ -62,8 +62,8 @@
                     <a href="https://duckduckgo.com">DuckDuckGo</a>
                     <ul>
                         <li>
-                            <a class="link-color" href="https://duckduckgo.com/search?q={{query}}">
-                                duckduckgo.com/search?q={{query}}
+                            <a class="link-color" href="https://duckduckgo.com/?q={{query}}">
+                                duckduckgo.com/?q={{query}}
                             </a>
                         </li>
                     </ul>


### PR DESCRIPTION
Fix the provided DuckDuckGo URL on the "Error" page so users may continue their search. Removed an extra search parameter: 'search'
https://duckduckgo.com/search?q=test
https://duckduckgo.com/?q=test
![whoogle ddg fix](https://github.com/user-attachments/assets/615aae9e-bc82-4e31-86a3-137e93e4fbde)
thanks