### PR TITLE
add a public instance for support

### DIFF
--- a/README.md
+++ b/README.md
@@ -704,6 +704,7 @@ A lot of the app currently piggybacks on Google's existing support for fetching 
 | [https://whoogle.privacydev.net](https://whoogle.privacydev.net) | 🇫🇷 FR | English | |
 | [https://wg.vern.cc](https://wg.vern.cc) | 🇺🇸 US | English |  |
 | [https://whoogle.lunar.icu](https://whoogle.lunar.icu) | 🇩🇪 DE | Multi-choice | ✅ |
+| [https://whoogle.4040940.xyz/](https://whoogle.4040940.xyz/) | 🇺🇸 US | English | ✅ |
 
 
 

--- a/misc/instances.txt
+++ b/misc/instances.txt
@@ -3,3 +3,4 @@ https://search.sethforprivacy.com
 https://whoogle.privacydev.net
 https://wg.vern.cc
 https://whoogle.lunar.icu
+https://whoogle.4040940.xyz


### PR DESCRIPTION
this is a simple tool compared to searxng. add a instance for support. as a backup.