### PR TITLE
fix: several bugs affecting alt links

### DIFF
--- a/app/filter.py
+++ b/app/filter.py
@@ -1,5 +1,4 @@
 import cssutils
-from app.utils.misc import SKIP_PREFIX
 from bs4 import BeautifulSoup
 from bs4.element import ResultSet, Tag
 from cryptography.fernet import Fernet

--- a/app/utils/misc.py
+++ b/app/utils/misc.py
@@ -11,8 +11,6 @@ from bs4 import BeautifulSoup as bsoup
 from cryptography.fernet import Fernet
 from flask import Request
 
-SKIP_PREFIX = ['//www.', '//mobile.', '//m.']
-
 ddg_favicon_site = 'http://icons.duckduckgo.com/ip2'
 
 empty_gif = base64.b64decode(

--- a/app/utils/results.py
+++ b/app/utils/results.py
@@ -1,6 +1,6 @@
 from app.models.config import Config
 from app.models.endpoint import Endpoint
-from app.utils.misc import list_to_dict, SKIP_PREFIX
+from app.utils.misc import list_to_dict
 from bs4 import BeautifulSoup, NavigableString
 import copy
 from flask import current_app
@@ -12,6 +12,7 @@ import re
 import warnings
 
 SKIP_ARGS = ['ref_src', 'utm']
+SKIP_PREFIX = ['//www.', '//mobile.', '//m.']
 GOOG_STATIC = 'www.gstatic.com'
 G_M_LOGO_URL = 'https://www.gstatic.com/m/images/icons/googleg.gif'
 GOOG_IMG = '/images/branding/searchlogo/1x/googlelogo'
@@ -235,7 +236,6 @@ def get_site_alt(link: str, site_alts: dict = SITE_ALTS) -> str:
                 # If a scheme is specified, remove everything before the
                 # first occurence of it
                 link = f'{parsed_alt.scheme}{link.split(parsed_alt.scheme, 1)[-1]}'
-
         break
 
     return link


### PR DESCRIPTION
This fixes a number of bugs:

1. This bug, https://github.com/benbusby/whoogle-search/issues/1230, where the subdomain is repeatedly reapplied to the same link. This was fixed by exiting the loop if the alt link is already present in the link. However, this is actually the symptom of a broader redundancy in the code: this loop [here](https://github.com/benbusby/whoogle-search/blob/main/app/filter.py#L652) calls get_site_alt for each link on the page, but then get_site_alt loops over all the site alts again [here](https://github.com/benbusby/whoogle-search/blob/main/app/utils/results.py#L198). In effect, this means the following is taking place:

```
foreach site alt
  foreach link
    foreach site alt
```

A broader refactor is needed to remove this redundancy/inefficiency. However, this PR contains the "exit if alt link is already present in the link" statement which is a working bandaid.

2. Adds edge case handling for simple.wikipedia.org which breaks if the provided alt link is a specific language of wikipedia.org

3. Fixes the link_desc field so that prefixes aren't ignored. Otherwise, we end up with link_descs like "www.https://old.reddit.com"