### PR TITLE
Update brotli to 1.1.0 to use pre-build binary for arm platform

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 attrs==22.2.0
 beautifulsoup4==4.11.2
-brotli==1.0.9
+brotli==1.1.0
 cachelib==0.10.2
 certifi==2024.7.4
 cffi==1.17.1


### PR DESCRIPTION
Related to CI worflow failed : https://github.com/benbusby/whoogle-search/actions/runs/17689792324
Related to issue : https://github.com/benbusby/whoogle-search/issues/1239

Build of Brotli on ARM seems not working anymore, not sure why because docker builder steps seems to using a correct fixed image version, same for the requirements.txt

To reproduce on a x86_64 host :

```
sudo docker buildx create --name container-builder --driver docker-container --bootstrap --use
sudo docker buildx build --tag benbusby/whoogle-search:latest --platform linux/arm64
```

This PR is bumping brotli to the [last version](https://github.com/google/brotli/releases/tag/v1.1.0) and bypass the building phase by using pre-builded binary provided by maintainers.

Don't know the impact of the upgrade on the projet. Feel free to close the PR.