### PR TITLE
Add missing dependency to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ include_package_data = True
 install_requires=
     beautifulsoup4
     brotli
+    cachetools
     cssutils
     cryptography
     defusedxml


### PR DESCRIPTION
This fixes e.g. pipx installs breaking on a missing cachetools module.