### PR TITLE
Fix Windows startup crash (WinError 1314) when os.symlink lacks privilege

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -12,6 +12,7 @@ from flask import Flask
 import json
 import logging.config
 import os
+import shutil
 import sys
 from stem import Signal
 import threading
@@ -225,6 +226,11 @@ for cb_dir in cache_busting_dirs:
         except FileExistsError:
             # Symlink hasn't changed, ignore
             pass
+        except OSError:
+            # Windows without symlink privilege raises OSError (WinError 1314,
+            # "a required privilege is not held by the client"); some filesystems
+            # can't symlink either. Fall back to copying so cache-busting still works.
+            shutil.copyfile(full_cb_path, build_path)
 
         # Create mapping for relative path urls
         map_path = build_path.replace(app.config['APP_ROOT'], '')


### PR DESCRIPTION
## Problem

On Windows, Whoogle crashes on startup for any account **without symlink privilege** — i.e. not running as administrator and without Developer Mode enabled (the default for most users).

The cache-busting static-file setup in `app/__init__.py` calls `os.symlink(...)`, which on those accounts raises:

```
OSError: [WinError 1314] A required privilege is not held by the client:
  '...\app\static\css\dark-theme.css' -> '...\app\static\build\dark-theme.<hash>.css'
```

Only `FileExistsError` was caught, so the `OSError` propagates and the app never starts.

## Reproduce (Windows 11, standard non-admin account, Developer Mode off)

```python
>>> import os, tempfile
>>> d = tempfile.mkdtemp(); s = os.path.join(d, "src"); open(s, "w").close()
>>> os.symlink(s, os.path.join(d, "link"))
OSError: [WinError 1314] A required privilege is not held by the client
```

`python -m app` then dies at `app/__init__.py` around line 224.

## Fix

Catch `OSError` in addition to `FileExistsError` and fall back to `shutil.copyfile`, so cache-busting still works when symlinks aren't permitted. Linux/macOS behaviour is unchanged (they keep symlinking).

## Testing

- **Before:** `python -m app` crashes with `WinError 1314` at the symlink line (reproduced on Windows 11, non-admin, Developer Mode off).
- **After:** starts clean and serves the homepage (HTTP 200).
- No behaviour change on Linux/macOS — the `OSError` branch only triggers when `os.symlink` actually fails.

Small change: one `except OSError` branch plus the `shutil` import.
