### PR TITLE
Fix SSRF in /element and /window proxy routes

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -29,6 +29,7 @@ from app.utils.results import bold_search_terms,\
     add_currency_card, check_currency, get_tabs_content
 from app.utils.search import Search, needs_https, has_captcha
 from app.utils.session import valid_user_session
+from app.utils.ssrf import is_safe_url
 from bs4 import BeautifulSoup as bsoup
 from flask import jsonify, make_response, request, redirect, render_template, \
     send_file, session, url_for, g
@@ -713,6 +714,10 @@ def element():
     if not validators.domain(domain):
         return send_file(io.BytesIO(empty_gif), mimetype='image/gif')
 
+    # Reject targets that resolve to internal/reserved addresses (SSRF).
+    if not is_safe_url(src_url):
+        return send_file(io.BytesIO(empty_gif), mimetype='image/gif')
+
     try:
         response = g.user_request.send(base_url=src_url)
 
@@ -753,6 +758,12 @@ def window():
 
     # Ensure requested URL has a valid domain
     if not validators.domain(target.netloc):
+        return render_template(
+            'error.html',
+            error_message='Invalid location'), 400
+
+    # Reject targets that resolve to internal/reserved addresses (SSRF).
+    if not is_safe_url(target_url):
         return render_template(
             'error.html',
             error_message='Invalid location'), 400

--- a/app/services/http_client.py
+++ b/app/services/http_client.py
@@ -7,6 +7,8 @@ from cachetools import TTLCache
 import ssl
 import os
 
+from app.utils.ssrf import ssrf_request_hook
+
 # Import h2 exceptions for better error handling
 try:
     from h2.exceptions import ProtocolError as H2ProtocolError
@@ -35,7 +37,8 @@ class HttpxClient:
             
         client_kwargs = dict(http2=http2,
                              timeout=timeout_seconds,
-                             follow_redirects=True)
+                             follow_redirects=True,
+                             event_hooks={'request': [ssrf_request_hook]})
         # Prefer future-proof mounts when proxies are provided; fall back to proxies=
         self._proxies = proxies or {}
         self._http2 = http2
@@ -196,7 +199,8 @@ class HttpxClient:
         # Recreate with same configuration
         client_kwargs = dict(timeout=self._timeout_seconds,
                              follow_redirects=True,
-                             http2=self._http2)
+                             http2=self._http2,
+                             event_hooks={'request': [ssrf_request_hook]})
 
         try:
             self._client = self._build_client(client_kwargs, self._verify)

--- a/app/utils/ssrf.py
+++ b/app/utils/ssrf.py
@@ -1,0 +1,133 @@
+"""SSRF protection for server-side fetches.
+
+Whoogle proxies remote resources (the /element image proxy and the /window
+page proxy) by fetching an attacker-supplied URL server-side. Without
+restriction, an anonymous request can point those routes at loopback,
+link-local, or RFC1918 addresses -- or a hostname such as ``127-0-0-1.nip.io``
+that *looks* like a public domain but resolves to an internal IP -- and use the
+Whoogle host as a proxy into the internal network or the cloud metadata
+endpoint (169.254.169.254).
+
+This module resolves the target host and rejects any request that would reach a
+non-public address. Because the shared HTTP client follows redirects, the guard
+is enforced as an httpx request event hook so that *every* hop (including
+redirect targets) is re-validated, not just the first URL.
+"""
+
+import ipaddress
+import os
+import socket
+import urllib.parse as urlparse
+from typing import Iterable
+
+import httpx
+
+
+class SSRFError(httpx.RequestError):
+    """Raised when a request targets a non-public / disallowed address.
+
+    Subclasses ``httpx.RequestError`` (and therefore ``httpx.HTTPError``) so it
+    is caught by the existing ``except httpx.HTTPError`` handlers in the proxy
+    routes and surfaces as a normal "could not fetch" outcome.
+    """
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+
+
+ALLOWED_SCHEMES = ('http', 'https')
+
+
+def _allowlisted_hosts() -> set:
+    """Hostnames an operator has explicitly opted to allow reaching internally.
+
+    Set ``WHOOGLE_ALLOW_INTERNAL_HOSTS`` to a comma-separated list of hostnames
+    to permit fetching them even if they resolve to a private address (e.g. a
+    self-hoster proxying a service on their LAN). Empty by default -- the
+    secure-by-default posture blocks all internal targets.
+    """
+    raw = os.environ.get('WHOOGLE_ALLOW_INTERNAL_HOSTS', '')
+    return {h.strip().lower() for h in raw.split(',') if h.strip()}
+
+
+def _ip_is_blocked(ip_str: str) -> bool:
+    """True if the address is not a routable public address."""
+    try:
+        ip = ipaddress.ip_address(ip_str)
+    except ValueError:
+        # Unparseable address -- fail closed.
+        return True
+
+    # Unwrap IPv4-mapped IPv6 (e.g. ::ffff:127.0.0.1) so the mapped v4 address
+    # is classified rather than the wrapper.
+    if ip.version == 6 and getattr(ip, 'ipv4_mapped', None) is not None:
+        ip = ip.ipv4_mapped
+
+    return (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local      # 169.254.0.0/16 -> cloud metadata, fe80::/10
+        or ip.is_reserved
+        or ip.is_multicast
+        or ip.is_unspecified
+    )
+
+
+def _resolve(host: str) -> Iterable[str]:
+    """Resolve a host to every IP it maps to (fails closed on error)."""
+    try:
+        infos = socket.getaddrinfo(host, None)
+    except (socket.gaierror, UnicodeError, OSError):
+        raise SSRFError(f'Could not resolve host: {host!r}')
+    return {info[4][0] for info in infos}
+
+
+def is_safe_url(url: str) -> bool:
+    """Return True only if *url* is http(s) and resolves to public IPs."""
+    try:
+        guard_url(url)
+        return True
+    except SSRFError:
+        return False
+
+
+def guard_url(url: str) -> None:
+    """Validate *url*; raise :class:`SSRFError` if it must not be fetched.
+
+    Rejects:
+      * non-http(s) schemes (file://, gopher://, ftp://, ...)
+      * missing/empty host
+      * a host that resolves to *any* non-public address
+        (loopback, RFC1918, link-local/metadata, reserved, multicast).
+
+    If any resolved address is internal the whole URL is rejected, so an
+    attacker cannot smuggle an internal IP alongside a public one in DNS.
+    """
+    if not url:
+        raise SSRFError('Empty URL')
+
+    parsed = urlparse.urlparse(url)
+    if parsed.scheme.lower() not in ALLOWED_SCHEMES:
+        raise SSRFError(f'Disallowed scheme: {parsed.scheme!r}')
+
+    host = parsed.hostname
+    if not host:
+        raise SSRFError('URL has no host')
+
+    if host.lower() in _allowlisted_hosts():
+        return
+
+    for ip_str in _resolve(host):
+        if _ip_is_blocked(ip_str):
+            raise SSRFError(
+                f'Refusing to fetch {host!r}: resolves to non-public '
+                f'address {ip_str}')
+
+
+def ssrf_request_hook(request: 'httpx.Request') -> None:
+    """httpx request event hook enforcing :func:`guard_url` on every hop.
+
+    Registered on the shared client so redirect targets are re-validated, not
+    just the initial URL.
+    """
+    guard_url(str(request.url))

--- a/test/test_ssrf.py
+++ b/test/test_ssrf.py
@@ -1,0 +1,137 @@
+import socket
+
+import httpx
+import pytest
+
+from app.utils import ssrf
+from app.utils.ssrf import (
+    SSRFError,
+    guard_url,
+    is_safe_url,
+    ssrf_request_hook,
+    _ip_is_blocked,
+)
+
+
+def _fake_resolver(mapping):
+    """Return a getaddrinfo stand-in that maps host -> list of IPs."""
+    def _getaddrinfo(host, *args, **kwargs):
+        if host not in mapping:
+            raise socket.gaierror('name resolution failed')
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, '', (ip, 0))
+                for ip in mapping[host]]
+    return _getaddrinfo
+
+
+@pytest.mark.parametrize('ip', [
+    '127.0.0.1',            # loopback
+    '10.0.0.5',            # RFC1918
+    '192.168.1.1',         # RFC1918
+    '172.16.0.1',          # RFC1918
+    '169.254.169.254',     # cloud metadata (link-local)
+    '0.0.0.0',             # unspecified
+    '::1',                 # IPv6 loopback
+    'fe80::1',             # IPv6 link-local
+    '::ffff:127.0.0.1',    # IPv4-mapped loopback
+])
+def test_internal_addresses_blocked(ip):
+    assert _ip_is_blocked(ip) is True
+
+
+@pytest.mark.parametrize('ip', ['93.184.216.34', '8.8.8.8', '1.1.1.1'])
+def test_public_addresses_allowed(ip):
+    assert _ip_is_blocked(ip) is False
+
+
+def test_guard_rejects_loopback_hostname(monkeypatch):
+    # A "valid domain" that resolves to loopback (the nip.io bypass class).
+    monkeypatch.setattr(
+        socket, 'getaddrinfo',
+        _fake_resolver({'127-0-0-1.nip.io': ['127.0.0.1']}))
+    with pytest.raises(SSRFError):
+        guard_url('http://127-0-0-1.nip.io/secret')
+    assert is_safe_url('http://127-0-0-1.nip.io/secret') is False
+
+
+def test_guard_rejects_metadata_host(monkeypatch):
+    monkeypatch.setattr(
+        socket, 'getaddrinfo',
+        _fake_resolver({'meta.evil.com': ['169.254.169.254']}))
+    assert is_safe_url('http://meta.evil.com/latest/meta-data/') is False
+
+
+def test_guard_allows_public_host(monkeypatch):
+    monkeypatch.setattr(
+        socket, 'getaddrinfo',
+        _fake_resolver({'example.com': ['93.184.216.34']}))
+    assert is_safe_url('https://example.com/logo.png') is True
+    guard_url('https://example.com/logo.png')  # does not raise
+
+
+def test_guard_rejects_mixed_public_and_internal(monkeypatch):
+    # DNS returning one public + one internal address must still be blocked.
+    monkeypatch.setattr(
+        socket, 'getaddrinfo',
+        _fake_resolver({'rebind.evil.com': ['93.184.216.34', '127.0.0.1']}))
+    assert is_safe_url('http://rebind.evil.com/') is False
+
+
+def test_guard_rejects_non_http_scheme():
+    with pytest.raises(SSRFError):
+        guard_url('file:///etc/passwd')
+    with pytest.raises(SSRFError):
+        guard_url('gopher://127.0.0.1:6379/_')
+
+
+def test_guard_rejects_empty_and_hostless():
+    with pytest.raises(SSRFError):
+        guard_url('')
+    with pytest.raises(SSRFError):
+        guard_url('http:///nohost')
+
+
+def test_allowlist_env_permits_internal(monkeypatch):
+    monkeypatch.setenv('WHOOGLE_ALLOW_INTERNAL_HOSTS', 'intranet.local')
+    monkeypatch.setattr(
+        socket, 'getaddrinfo',
+        _fake_resolver({'intranet.local': ['10.1.2.3']}))
+    # Allowlisted host bypasses the resolver check entirely.
+    assert is_safe_url('http://intranet.local/dashboard') is True
+
+
+def test_request_hook_blocks_redirect_to_internal(monkeypatch):
+    # Simulates httpx invoking the event hook for a redirect hop to loopback.
+    monkeypatch.setattr(
+        socket, 'getaddrinfo',
+        _fake_resolver({'127-0-0-1.nip.io': ['127.0.0.1']}))
+    req = httpx.Request('GET', 'http://127-0-0-1.nip.io/secret')
+    with pytest.raises(SSRFError):
+        ssrf_request_hook(req)
+
+
+def test_ssrferror_is_httpx_error():
+    # Must be catchable by existing `except httpx.HTTPError` handlers.
+    assert issubclass(SSRFError, httpx.HTTPError)
+
+
+def test_element_route_blocks_loopback_without_fetching(client, monkeypatch):
+    """End-to-end: /element must not fetch a host that resolves to loopback."""
+    from app.request import Request
+
+    monkeypatch.setattr(
+        socket, 'getaddrinfo',
+        _fake_resolver({'internal.test': ['127.0.0.1']}))
+
+    calls = []
+
+    def spy_send(self, *args, **kwargs):
+        calls.append(kwargs.get('base_url', args[0] if args else None))
+        raise AssertionError('send() must not be reached for a blocked target')
+
+    monkeypatch.setattr(Request, 'send', spy_send)
+
+    resp = client.get('/element?url=http://internal.test/secret&type=image/png')
+
+    assert resp.status_code == 200          # served the empty gif, not the secret
+    assert resp.data[:6] in (b'GIF87a', b'GIF89a')
+    assert calls == []                      # server never made the internal request


### PR DESCRIPTION
# Fix SSRF in `/element` and `/window` proxy routes

## Summary

The `/element` (image proxy) and `/window` (page proxy) routes fetch a
user-supplied URL server-side, but only validate that the hostname is a
*syntactically* valid domain via `validators.domain()`. They never resolve the
host or check the resulting IP.

A hostname like `127-0-0-1.nip.io` passes `validators.domain()` yet resolves to
`127.0.0.1`. With the default configuration no authentication is required, so an
anonymous request can make the Whoogle host connect to loopback, other machines
on the internal network, or the cloud metadata endpoint
(`169.254.169.254`) and read the response back — a classic unauthenticated SSRF.

## Steps to reproduce (before this patch)

Run an internal-only service on loopback, then:

```
GET /element?url=aHR0cDovLzEyNy0wLTAtMS5uaXAuaW8vc2VjcmV0&type=image%2Fpng
```

(the base64 decodes to `http://127-0-0-1.nip.io/secret`). `nip.io` resolves the
name to `127.0.0.1`, `validators.domain()` accepts it, and the internal
service's response body is returned to the caller. The same works against
`/window?location=…`. On cloud deployments this reaches the IMDSv1 metadata
endpoint.

## Root cause

`app/routes.py` — both routes gate only on `validators.domain(netloc)`, which is
a string/format check, not an address check. The shared HTTP client
(`app/services/http_client.py`) is built with `follow_redirects=True`, so even a
host-based allow check on the first URL would be bypassable via a `302` to an
internal address.

## Fix

- **`app/utils/ssrf.py`** (new): resolves the target host and rejects any
  request that would reach a non-public address — loopback, private (RFC1918),
  link-local (incl. `169.254.169.254`), reserved, multicast, or unspecified —
  covering IPv4, IPv6, and IPv4-mapped IPv6. If *any* resolved address is
  internal, the whole URL is rejected (so an attacker can't smuggle an internal
  IP alongside a public one). Non-`http(s)` schemes (`file://`, `gopher://`, …)
  are rejected too.
- **`app/services/http_client.py`**: the guard is registered as an httpx
  `request` event hook, so **every hop — including redirect targets — is
  re-validated**, closing the redirect bypass.
- **`app/routes.py`**: `/element` and `/window` also call the guard at the entry
  point for a clean rejection (empty GIF / `400`).
- **Opt-in escape hatch**: operators who intentionally proxy internal hosts can
  allowlist specific hostnames via `WHOOGLE_ALLOW_INTERNAL_HOSTS`
  (comma-separated). Empty by default — secure by default.

`SSRFError` subclasses `httpx.RequestError`, so it is transparently caught by
the existing `except httpx.HTTPError` handlers in the proxy routes.

## Tests

`test/test_ssrf.py` (new, 22 cases) covers address classification (v4/v6/mapped),
the `nip.io`/metadata bypass class, mixed public+internal DNS answers, scheme
rejection, the redirect-hop event hook, the `WHOOGLE_ALLOW_INTERNAL_HOSTS`
allowlist, and an end-to-end `/element` test asserting the server serves the
empty GIF and **never makes the internal request**.

## Residual note

This resolves-then-checks approach leaves a narrow DNS-rebinding TOCTOU window
(host re-resolved by httpx at connect time). A follow-up could pin the validated
IP for the connection; the event-hook check already blocks the practical
`nip.io`/static-DNS vectors reported here.
