### PR TITLE
Fix IndexError (HTTP 500) in check_currency on new Google markup

### DIFF
--- a/app/utils/results.py
+++ b/app/utils/results.py
@@ -319,6 +319,11 @@ def check_currency(response: str) -> dict:
             else:
                 return {}
         currency_link = currency_link.find_all(class_='BNeawe')
+        # Google periodically changes the conversion-widget markup (e.g. dropping the
+        # BNeawe class), which leaves <2 nodes here and used to crash with an IndexError
+        # -> HTTP 500 on every currency/crypto query. Bail gracefully instead.
+        if len(currency_link) < 2:
+            return {}
         currency1 = currency_link[0].text
         currency2 = currency_link[1].text
         currency1 = currency1.rstrip('=').split(' ', 1)
@@ -326,6 +331,8 @@ def check_currency(response: str) -> dict:
 
         # Handle differences in currency formatting
         # i.e. "5.000" vs "5,000"
+        if len(currency1) < 2 or len(currency2) < 2 or len(currency2[0]) < 3:
+            return {}
         if currency2[0][-3] == ',':
             currency1[0] = currency1[0].replace('.', '')
             currency1[0] = currency1[0].replace(',', '.')


### PR DESCRIPTION
### Problem

Any currency / crypto / conversion query (e.g. `bitcoin price usd`, `100 usd to inr`, `ethereum price`) currently returns an **HTTP 500**. The traceback:

```
  conversion = check_currency(str(response))
IndexError: list index out of range
```

`check_currency()` (`app/utils/results.py`) locates the conversion widget, then calls `find_all(class_='BNeawe')` and immediately indexes `[0]` and `[1]`. Google's newer SERP layout no longer emits the `BNeawe` class, so `find_all` returns an empty list and the unconditional indexing raises `IndexError`, which propagates as a 500 for the entire search — not just the conversion card.

### Fix

Guard the node count before indexing, and likewise guard the currency-format access (`currency2[0][-3]`). When the expected structure isn't present, bail out to `{}` so the search returns normally, just without the conversion card. No behavior change when the widget markup *is* present.

### Testing

Reproduced the 500 on `bitcoin price usd`, `100 usd to inr`, `ethereum price`, `btc to usd` on a current `benbusby/whoogle-search` container. After the patch, all of those return results (200) again; non-currency queries are unaffected.