### PR TITLE
fix: stop preference tokens from exposing CSE credentials

### DIFF
--- a/app/models/config.py
+++ b/app/models/config.py
@@ -284,7 +284,12 @@ class Config:
         return urlsafe_b64encode(kdf_key)
 
     def _encode_preferences(self) -> str:
-        preferences_json = json.dumps(self.get_attrs()).encode()
+        safe_preferences = {
+            key: value
+            for key, value in self.get_attrs().items()
+            if self.is_safe_key(key)
+        }
+        preferences_json = json.dumps(safe_preferences).encode()
         compressed_preferences = brotli.compress(preferences_json)
 
         if self.preferences_encrypted and self.preferences_key:
@@ -312,4 +317,3 @@ class Config:
             config = {}
 
         return config
-

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,0 +1,19 @@
+from app import app
+from app.models.config import Config
+
+
+def test_preferences_token_only_includes_safe_keys(monkeypatch):
+    monkeypatch.setenv('WHOOGLE_CSE_API_KEY', 'cse-secret')
+    monkeypatch.setenv('WHOOGLE_CSE_ID', 'cse-id')
+    monkeypatch.setenv('WHOOGLE_CONFIG_PREFERENCES_KEY', 'preferences-secret')
+    monkeypatch.setenv('WHOOGLE_CONFIG_PREFERENCES_ENCRYPTED', '0')
+
+    with app.app_context():
+        config = Config()
+        decoded_preferences = config._decode_preferences(config.preferences)
+
+    assert set(decoded_preferences) == set(config.safe_keys)
+    assert decoded_preferences['theme'] == config.theme
+    assert 'cse_api_key' not in decoded_preferences
+    assert 'cse_id' not in decoded_preferences
+    assert 'preferences_key' not in decoded_preferences


### PR DESCRIPTION
Fixes #1308

`Config.preferences` is embedded in search forms and user-visible links, but `_encode_preferences()` currently serializes every string and boolean returned by `get_attrs()`. That includes `cse_api_key`, `cse_id`, and `preferences_key`.

This change filters the serialized values through the existing `safe_keys` allowlist before compression or encryption. Those are already the only keys `from_params()` will apply, so valid shareable preferences keep working while server-only values stay out of the token.

The regression test creates a config with nonempty CSE and preference secrets, decodes its generated token, and verifies that the emitted key set exactly matches `safe_keys`. It also checks that the three sensitive values are absent and a normal theme preference survives.

Local checks

- compiled the changed source and test files
- parsed both files and verified the encoder calls `is_safe_key`
- `git diff --check`

The application dependencies are not installed in this checkout, so the full pytest run is left to repository CI.